### PR TITLE
Add the 'dyn' keyword where necessary

### DIFF
--- a/src/find/matchers/exec.rs
+++ b/src/find/matchers/exec.rs
@@ -29,7 +29,7 @@ impl SingleExecMatcher {
         executable: &str,
         args: &[&str],
         exec_in_parent_dir: bool,
-    ) -> Result<SingleExecMatcher, Box<Error>> {
+    ) -> Result<SingleExecMatcher, Box<dyn Error>> {
         let transformed_args = args
             .iter()
             .map(|&a| match a {
@@ -49,7 +49,7 @@ impl SingleExecMatcher {
         executable: &str,
         args: &[&str],
         exec_in_parent_dir: bool,
-    ) -> Result<Box<Matcher>, Box<Error>> {
+    ) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
         Ok(Box::new(SingleExecMatcher::new(
             executable,
             args,

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -26,11 +26,11 @@ use super::{Config, Dependencies};
 /// from the file/directory info.
 pub struct MatcherIO<'a> {
     should_skip_dir: bool,
-    deps: &'a Dependencies<'a>,
+    deps: &'a dyn Dependencies<'a>,
 }
 
 impl<'a> MatcherIO<'a> {
-    pub fn new(deps: &'a Dependencies<'a>) -> MatcherIO<'a> {
+    pub fn new(deps: &'a dyn Dependencies<'a>) -> MatcherIO<'a> {
         MatcherIO {
             deps: deps,
             should_skip_dir: false,
@@ -107,7 +107,7 @@ impl ComparableValue {
 pub fn build_top_level_matcher(
     args: &[&str],
     config: &mut Config,
-) -> Result<Box<Matcher>, Box<Error>> {
+) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
     let (_, top_level_matcher) = (build_matcher_tree(args, config, 0, false))?;
 
     // if the matcher doesn't have any side-effects, then we default to printing
@@ -125,7 +125,7 @@ fn are_more_expressions(args: &[&str], index: usize) -> bool {
     (index < args.len() - 1) && args[index + 1] != ")"
 }
 
-fn convert_arg_to_number(option_name: &str, value_as_string: &str) -> Result<usize, Box<Error>> {
+fn convert_arg_to_number(option_name: &str, value_as_string: &str) -> Result<usize, Box<dyn Error>> {
     match value_as_string.parse::<usize>() {
         Ok(val) => Ok(val),
         _ => Err(From::from(format!(
@@ -139,7 +139,7 @@ fn convert_arg_to_number(option_name: &str, value_as_string: &str) -> Result<usi
 fn convert_arg_to_comparable_value(
     option_name: &str,
     value_as_string: &str,
-) -> Result<ComparableValue, Box<Error>> {
+) -> Result<ComparableValue, Box<dyn Error>> {
     let re = Regex::new(r"([+-]?)(\d+)$")?;
     if let Some(groups) = re.captures(value_as_string) {
         if let Ok(val) = groups[2].parse::<u64>() {
@@ -160,7 +160,7 @@ fn convert_arg_to_comparable_value(
 fn convert_arg_to_comparable_value_and_suffix(
     option_name: &str,
     value_as_string: &str,
-) -> Result<(ComparableValue, String), Box<Error>> {
+) -> Result<(ComparableValue, String), Box<dyn Error>> {
     let re = Regex::new(r"([+-]?)(\d+)(.*)$")?;
     if let Some(groups) = re.captures(value_as_string) {
         if let Ok(val) = groups[2].parse::<u64>() {
@@ -190,7 +190,7 @@ fn build_matcher_tree(
     config: &mut Config,
     arg_index: usize,
     expecting_bracket: bool,
-) -> Result<(usize, Box<Matcher>), Box<Error>> {
+) -> Result<(usize, Box<dyn Matcher>), Box<dyn Error>> {
     let mut top_level_matcher = logical_matchers::ListMatcherBuilder::new();
 
     // can't use getopts for a variety or reasons:

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -23,7 +23,7 @@ impl NameMatcher {
         Ok(NameMatcher { pattern: p })
     }
 
-    pub fn new_box(pattern_string: &str) -> Result<Box<Matcher>, PatternError> {
+    pub fn new_box(pattern_string: &str) -> Result<Box<dyn Matcher>, PatternError> {
         Ok(Box::new(NameMatcher::new(pattern_string)?))
     }
 }
@@ -48,7 +48,7 @@ impl CaselessNameMatcher {
         Ok(CaselessNameMatcher { pattern: p })
     }
 
-    pub fn new_box(pattern_string: &str) -> Result<Box<Matcher>, PatternError> {
+    pub fn new_box(pattern_string: &str) -> Result<Box<dyn Matcher>, PatternError> {
         Ok(Box::new(CaselessNameMatcher::new(pattern_string)?))
     }
 }

--- a/src/find/matchers/perm.rs
+++ b/src/find/matchers/perm.rs
@@ -30,8 +30,8 @@ pub enum ComparisonType {
 
 #[cfg(unix)]
 impl FromStr for ComparisonType {
-    type Err = Box<Error>;
-    fn from_str(s: &str) -> Result<ComparisonType, Box<Error>> {
+    type Err = Box<dyn Error>;
+    fn from_str(s: &str) -> Result<ComparisonType, Box<dyn Error>> {
         Ok(match s {
             "" => ComparisonType::Exact,
             "-" => ComparisonType::AtLeast,
@@ -94,14 +94,14 @@ mod parsing {
             }
         }
 
-        fn error(&self) -> Result<(), Box<Error>> {
+        fn error(&self) -> Result<(), Box<dyn Error>> {
             Err(From::from(format!(
                 "invalid mode '{}'",
                 self.string_pattern
             )))
         }
 
-        fn handle_char(&mut self, char: &char) -> Result<(), Box<Error>> {
+        fn handle_char(&mut self, char: &char) -> Result<(), Box<dyn Error>> {
             if let ParserState::Beginning = self.state {};
 
             match *char {
@@ -230,7 +230,7 @@ mod parsing {
         }
     }
 
-    pub fn parse(string_value: &str) -> Result<(u32, ComparisonType), Box<Error>> {
+    pub fn parse(string_value: &str) -> Result<(u32, ComparisonType), Box<dyn Error>> {
         // safe to unwrap as the regex is a compile-time constant.
         let re = Regex::new("^([/-]?)([0-7]+)$").unwrap();
 
@@ -270,7 +270,7 @@ pub struct PermMatcher {}
 
 impl PermMatcher {
     #[cfg(unix)]
-    pub fn new(pattern: &str) -> Result<PermMatcher, Box<Error>> {
+    pub fn new(pattern: &str) -> Result<PermMatcher, Box<dyn Error>> {
         let (bit_pattern, comparison_type) = parsing::parse(pattern)?;
         Ok(PermMatcher {
             pattern: bit_pattern,
@@ -279,13 +279,13 @@ impl PermMatcher {
     }
 
     #[cfg(not(unix))]
-    pub fn new(_dummy_pattern: &str) -> Result<PermMatcher, Box<Error>> {
+    pub fn new(_dummy_pattern: &str) -> Result<PermMatcher, Box<dyn Error>> {
         Err(From::from(
             "Permission matching is not available on this platform",
         ))
     }
 
-    pub fn new_box(pattern: &str) -> Result<Box<Matcher>, Box<Error>> {
+    pub fn new_box(pattern: &str) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
         Ok(Box::new(PermMatcher::new(pattern)?))
     }
 }

--- a/src/find/matchers/printer.rs
+++ b/src/find/matchers/printer.rs
@@ -16,7 +16,7 @@ impl Printer {
         Printer {}
     }
 
-    pub fn new_box() -> Box<Matcher> {
+    pub fn new_box() -> Box<dyn Matcher> {
         Box::new(Printer::new())
     }
 }

--- a/src/find/matchers/prune.rs
+++ b/src/find/matchers/prune.rs
@@ -16,7 +16,7 @@ impl PruneMatcher {
         PruneMatcher {}
     }
 
-    pub fn new_box() -> Box<Matcher> {
+    pub fn new_box() -> Box<dyn Matcher> {
         Box::new(PruneMatcher::new())
     }
 }

--- a/src/find/matchers/size.rs
+++ b/src/find/matchers/size.rs
@@ -22,8 +22,8 @@ enum Unit {
 }
 
 impl FromStr for Unit {
-    type Err = Box<Error>;
-    fn from_str(s: &str) -> Result<Unit, Box<Error>> {
+    type Err = Box<dyn Error>;
+    fn from_str(s: &str) -> Result<Unit, Box<dyn Error>> {
         Ok(match s {
             "c" => Unit::Byte,
             "w" => Unit::TwoByteWord,
@@ -75,7 +75,7 @@ impl SizeMatcher {
     pub fn new(
         value_to_match: ComparableValue,
         suffix_string: &str,
-    ) -> Result<SizeMatcher, Box<Error>> {
+    ) -> Result<SizeMatcher, Box<dyn Error>> {
         Ok(SizeMatcher {
             unit: suffix_string.parse()?,
             value_to_match: value_to_match,
@@ -85,7 +85,7 @@ impl SizeMatcher {
     pub fn new_box(
         value_to_match: ComparableValue,
         suffix_string: &str,
-    ) -> Result<Box<Matcher>, Box<Error>> {
+    ) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
         Ok(Box::new(SizeMatcher::new(value_to_match, suffix_string)?))
     }
 }

--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -21,20 +21,20 @@ pub struct NewerMatcher {
 }
 
 impl NewerMatcher {
-    pub fn new(path_to_file: &str) -> Result<NewerMatcher, Box<Error>> {
+    pub fn new(path_to_file: &str) -> Result<NewerMatcher, Box<dyn Error>> {
         let metadata = fs::metadata(path_to_file)?;
         Ok(NewerMatcher {
             given_modification_time: metadata.modified()?,
         })
     }
 
-    pub fn new_box(path_to_file: &str) -> Result<Box<Matcher>, Box<Error>> {
+    pub fn new_box(path_to_file: &str) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
         Ok(Box::new(NewerMatcher::new(path_to_file)?))
     }
 
     /// Impementation of matches that returns a result, allowing use to use try!
     /// to deal with the errors.
-    fn matches_impl(&self, file_info: &DirEntry) -> Result<bool, Box<Error>> {
+    fn matches_impl(&self, file_info: &DirEntry) -> Result<bool, Box<dyn Error>> {
         let this_time = file_info.metadata()?.modified()?;
         // duration_since returns an Ok duration if this_time <= given_modification_time
         // and returns an Err (with a duration) otherwise. So if this_time >
@@ -111,7 +111,7 @@ impl Matcher for FileTimeMatcher {
 impl FileTimeMatcher {
     /// Impementation of matches that returns a result, allowing use to use try!
     /// to deal with the errors.
-    fn matches_impl(&self, file_info: &DirEntry, now: SystemTime) -> Result<bool, Box<Error>> {
+    fn matches_impl(&self, file_info: &DirEntry, now: SystemTime) -> Result<bool, Box<dyn Error>> {
         let this_time = self.file_time_type.get_file_time(file_info.metadata()?)?;
         let mut is_negative = false;
         // durations can't be negative. So duration_since returns a duration
@@ -140,7 +140,7 @@ impl FileTimeMatcher {
         }
     }
 
-    pub fn new_box(file_time_type: FileTimeType, days: ComparableValue) -> Box<Matcher> {
+    pub fn new_box(file_time_type: FileTimeType, days: ComparableValue) -> Box<dyn Matcher> {
         Box::new(FileTimeMatcher::new(file_time_type, days))
     }
 }

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -16,7 +16,7 @@ pub struct TypeMatcher {
 }
 
 impl TypeMatcher {
-    pub fn new(type_string: &str) -> Result<TypeMatcher, Box<Error>> {
+    pub fn new(type_string: &str) -> Result<TypeMatcher, Box<dyn Error>> {
         let function = match type_string {
             "f" => FileType::is_file,
             "d" => FileType::is_dir,
@@ -38,7 +38,7 @@ impl TypeMatcher {
         })
     }
 
-    pub fn new_box(type_string: &str) -> Result<Box<Matcher>, Box<Error>> {
+    pub fn new_box(type_string: &str) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
         Ok(Box::new(TypeMatcher::new(type_string)?))
     }
 }


### PR DESCRIPTION
The keyword is needed for trait objects and is intended to improve
readability.
https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html