### PR TITLE
Implement -delete (#13) with tests (supersedes PR #22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+on: [push, pull_request]
+
+name: Basic CI
+
+jobs:
+  check:
+    name: cargo check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: cargo test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: cargo fmt --all -- --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: cargo clippy -- -D warnings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,19 +10,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc1679af9a1ab4bea16f228b05d18f8363f8327b1fa8db00d2760cfafc6b61e"
+dependencies = [
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bitflags"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "findutils"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "glob",
+ "predicates",
  "regex",
+ "serial_test",
  "tempdir",
  "walkdir",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -48,25 +97,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "lazy_static"
-version = "1.1.0"
+name = "instant"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "version_check",
+ "cfg-if",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.28"
+name = "lazy_static"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7b49972ee23d8aa1026c365a5b440ba08e35075f18c459980c7395c221ec48"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+
+[[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "predicates"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73dd9b7b200044694dfede9edf907c1ca19630908443e9447e624993700c6932"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3dbeaaf793584e29c58c7e3a82bbb3c7c06b63cea68d13b0e3cddc124104dc"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee95d988ee893cb35c06b148c80ed2cd52c8eea927f50ba7a0be1a786aeab73"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -78,6 +229,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
@@ -116,6 +273,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
+
+[[package]]
+name = "syn"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +337,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.1.4"
+name = "treeline"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -153,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ walkdir = "2.3"
 tempdir = "0.3"
 regex = "1.4"
 
+[dev-dependencies]
+assert_cmd = "1"
+predicates = "1"
+serial_test = "0.5"
+
 [[bin]]
 name = "find"
 path = "src/find/main.rs"

--- a/src/find/matchers/delete.rs
+++ b/src/find/matchers/delete.rs
@@ -8,8 +8,8 @@
  */
 
 use std::env;
-use std::io::{self, stderr, Write};
 use std::fs::{self, FileType};
+use std::io::{self, stderr, Write};
 use std::path::{Path, PathBuf};
 
 use walkdir::DirEntry;
@@ -17,13 +17,13 @@ use walkdir::DirEntry;
 use find::matchers::{Matcher, MatcherIO};
 
 pub struct DeleteMatcher {
-    current_dir: PathBuf
+    current_dir: PathBuf,
 }
 
 impl DeleteMatcher {
     pub fn new() -> io::Result<DeleteMatcher> {
         Ok(DeleteMatcher {
-            current_dir: env::current_dir()?
+            current_dir: env::current_dir()?,
         })
     }
 
@@ -50,10 +50,13 @@ impl Matcher for DeleteMatcher {
         match self.delete(path, file_info.file_type()) {
             Ok(_) => true,
             Err(f) => {
-                writeln!(&mut stderr(),
-                         "Failed to delete {}: {}",
-                         file_info.path().to_string_lossy(),
-                         f).unwrap();
+                writeln!(
+                    &mut stderr(),
+                    "Failed to delete {}: {}",
+                    file_info.path().to_string_lossy(),
+                    f
+                )
+                .unwrap();
                 false
             }
         }
@@ -65,6 +68,4 @@ impl Matcher for DeleteMatcher {
 }
 
 #[cfg(test)]
-mod tests {
-
-}
+mod tests {}

--- a/src/find/matchers/delete.rs
+++ b/src/find/matchers/delete.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use walkdir::DirEntry;
 
-use find::matchers::{Matcher, MatcherIO};
+use super::{Matcher, MatcherIO};
 
 pub struct DeleteMatcher {
     current_dir: PathBuf,

--- a/src/find/matchers/delete.rs
+++ b/src/find/matchers/delete.rs
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the uutils findutils package.
+ *
+ * (c) Arcterus <arcterus@mail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use std::io::{self, stderr, Write};
+use std::fs::{self, FileType};
+use std::path::Path;
+
+use walkdir::DirEntry;
+
+use find::matchers::{Matcher, MatcherIO};
+
+pub struct DeleteMatcher;
+
+impl DeleteMatcher {
+    pub fn new() -> DeleteMatcher {
+        DeleteMatcher
+    }
+
+    pub fn new_box() -> Box<Matcher> {
+        Box::new(DeleteMatcher::new())
+    }
+
+    fn delete(&self, file_path: &Path, file_type: FileType) -> io::Result<()> {
+        if file_type.is_file() || file_type.is_symlink() {
+            fs::remove_file(file_path)
+        } else if file_type.is_dir() {
+            fs::remove_dir(file_path)
+        } else {
+            unimplemented!() // TODO: not sure what find does for block devices, etc.
+        }
+    }
+}
+
+impl Matcher for DeleteMatcher {
+    fn matches(&self, file_info: &DirEntry, _: &mut MatcherIO) -> bool {
+        match self.delete(file_info.path(), file_info.file_type()) {
+            Ok(_) => true,
+            Err(f) => {
+                writeln!(&mut stderr(),
+                         "Failed to delete {}: {}",
+                         file_info.path().to_string_lossy(),
+                         f).unwrap();
+                false
+            }
+        }
+    }
+
+    fn has_side_effects(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+}

--- a/src/find/matchers/delete.rs
+++ b/src/find/matchers/delete.rs
@@ -7,28 +7,23 @@
  * file that was distributed with this source code.
  */
 
-use std::env;
 use std::fs::{self, FileType};
 use std::io::{self, stderr, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use walkdir::DirEntry;
 
 use super::{Matcher, MatcherIO};
 
-pub struct DeleteMatcher {
-    current_dir: PathBuf,
-}
+pub struct DeleteMatcher;
 
 impl DeleteMatcher {
-    pub fn new() -> io::Result<DeleteMatcher> {
-        Ok(DeleteMatcher {
-            current_dir: env::current_dir()?,
-        })
+    pub fn new() -> DeleteMatcher {
+        DeleteMatcher
     }
 
     pub fn new_box() -> io::Result<Box<dyn Matcher>> {
-        Ok(Box::new(DeleteMatcher::new()?))
+        Ok(Box::new(DeleteMatcher::new()))
     }
 
     fn delete(&self, file_path: &Path, file_type: FileType) -> io::Result<()> {
@@ -43,20 +38,19 @@ impl DeleteMatcher {
 impl Matcher for DeleteMatcher {
     fn matches(&self, file_info: &DirEntry, _: &mut MatcherIO) -> bool {
         let path = file_info.path();
-        if path == self.current_dir {
+        let path_str = path.to_string_lossy();
+
+        // This is a quirk in find's traditional semantics probably due to
+        // POSIX rmdir() not accepting "." (EINVAL). std::fs::remove_dir()
+        // inherits the same behavior, so no reason to buck tradition.
+        if path_str == "." {
             return false;
         }
 
         match self.delete(path, file_info.file_type()) {
             Ok(_) => true,
-            Err(f) => {
-                writeln!(
-                    &mut stderr(),
-                    "Failed to delete {}: {}",
-                    file_info.path().to_string_lossy(),
-                    f
-                )
-                .unwrap();
+            Err(e) => {
+                writeln!(&mut stderr(), "Failed to delete {}: {}", path_str, e).unwrap();
                 false
             }
         }
@@ -68,4 +62,41 @@ impl Matcher for DeleteMatcher {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use std::fs::File;
+    use tempdir::TempDir;
+
+    use super::*;
+    use crate::find::matchers::tests::get_dir_entry_for;
+    use crate::find::tests::FakeDependencies;
+
+    #[test]
+    fn delete_matcher() {
+        let matcher = DeleteMatcher::new();
+        let deps = FakeDependencies::new();
+
+        let temp_dir = TempDir::new_in("test_data", "delete_matcher").expect("made temp dir");
+        let temp_dir_path = temp_dir.path().to_string_lossy();
+        File::create(temp_dir.path().join("test")).expect("created test file");
+        let test_entry = get_dir_entry_for(&temp_dir_path, "test");
+        assert!(
+            matcher.matches(&test_entry, &mut deps.new_matcher_io()),
+            "DeleteMatcher should match a simple file",
+        );
+        assert!(
+            !temp_dir.path().join("test").exists(),
+            "DeleteMatcher should actually delete files it matches",
+        );
+
+        let temp_dir_name = temp_dir.path().file_name().unwrap().to_string_lossy();
+        let temp_dir_entry = get_dir_entry_for("test_data", &temp_dir_name);
+        assert!(
+            matcher.matches(&temp_dir_entry, &mut deps.new_matcher_io()),
+            "DeleteMatcher should match directories",
+        );
+        assert!(
+            !temp_dir.path().exists(),
+            "DeleteMatcher should actually delete (empty) directories it matches",
+        );
+    }
+}

--- a/src/find/matchers/delete.rs
+++ b/src/find/matchers/delete.rs
@@ -27,7 +27,7 @@ impl DeleteMatcher {
         })
     }
 
-    pub fn new_box() -> io::Result<Box<Matcher>> {
+    pub fn new_box() -> io::Result<Box<dyn Matcher>> {
         Ok(Box::new(DeleteMatcher::new()?))
     }
 

--- a/src/find/matchers/delete.rs
+++ b/src/find/matchers/delete.rs
@@ -44,7 +44,7 @@ impl Matcher for DeleteMatcher {
         // POSIX rmdir() not accepting "." (EINVAL). std::fs::remove_dir()
         // inherits the same behavior, so no reason to buck tradition.
         if path_str == "." {
-            return false;
+            return true;
         }
 
         match self.delete(path, file_info.file_type()) {

--- a/src/find/matchers/exec.rs
+++ b/src/find/matchers/exec.rs
@@ -41,7 +41,7 @@ impl SingleExecMatcher {
         Ok(SingleExecMatcher {
             executable: executable.to_string(),
             args: transformed_args,
-            exec_in_parent_dir: exec_in_parent_dir,
+            exec_in_parent_dir,
         })
     }
 
@@ -72,9 +72,9 @@ impl Matcher for SingleExecMatcher {
         };
 
         for arg in &self.args {
-            command.arg(match arg {
-                &Arg::LiteralArg(ref a) => a.as_os_str(),
-                &Arg::Filename => path_to_file.as_os_str(),
+            command.arg(match *arg {
+                Arg::LiteralArg(ref a) => a.as_os_str(),
+                Arg::Filename => path_to_file.as_os_str(),
             });
         }
         if self.exec_in_parent_dir {
@@ -85,16 +85,16 @@ impl Matcher for SingleExecMatcher {
             }
         }
         match command.status() {
-            Ok(status) => return status.success(),
+            Ok(status) => status.success(),
             Err(e) => {
                 writeln!(&mut stderr(), "Failed to run {}: {}", self.executable, e).unwrap();
-                return false;
+                false
             }
         }
     }
 
     fn has_side_effects(&self) -> bool {
-        return true;
+        true
     }
 }
 

--- a/src/find/matchers/logical_matchers.rs
+++ b/src/find/matchers/logical_matchers.rs
@@ -534,5 +534,4 @@ mod tests {
         assert!(has_fx.has_side_effects());
         assert!(!hasnt_fx.has_side_effects());
     }
-
 }

--- a/src/find/matchers/logical_matchers.rs
+++ b/src/find/matchers/logical_matchers.rs
@@ -26,9 +26,7 @@ pub struct AndMatcher {
 
 impl AndMatcher {
     pub fn new(submatchers: Vec<Box<dyn Matcher>>) -> AndMatcher {
-        AndMatcher {
-            submatchers: submatchers,
-        }
+        AndMatcher { submatchers }
     }
 }
 
@@ -97,9 +95,7 @@ pub struct OrMatcher {
 
 impl OrMatcher {
     pub fn new(submatchers: Vec<Box<dyn Matcher>>) -> OrMatcher {
-        OrMatcher {
-            submatchers: submatchers,
-        }
+        OrMatcher { submatchers }
     }
 }
 
@@ -189,9 +185,7 @@ pub struct ListMatcher {
 
 impl ListMatcher {
     pub fn new(submatchers: Vec<Box<dyn Matcher>>) -> ListMatcher {
-        ListMatcher {
-            submatchers: submatchers,
-        }
+        ListMatcher { submatchers }
     }
 }
 
@@ -331,9 +325,7 @@ pub struct NotMatcher {
 
 impl NotMatcher {
     pub fn new(submatcher: Box<dyn Matcher>) -> NotMatcher {
-        NotMatcher {
-            submatcher: submatcher,
-        }
+        NotMatcher { submatcher }
     }
 
     pub fn new_box(submatcher: Box<dyn Matcher>) -> Box<NotMatcher> {

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+mod delete;
 pub mod exec;
 mod logical_matchers;
 mod name;
@@ -224,6 +225,11 @@ fn build_matcher_tree(
                 }
                 i += 1;
                 Some(type_matcher::TypeMatcher::new_box(args[i])?)
+            }
+            "-delete" => {
+                // -delete implicitly requires -depth
+                config.depth_first = true;
+                Some(delete::DeleteMatcher::new_box())
             }
             "-newer" => {
                 if i >= args.len() - 1 {

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -126,7 +126,10 @@ fn are_more_expressions(args: &[&str], index: usize) -> bool {
     (index < args.len() - 1) && args[index + 1] != ")"
 }
 
-fn convert_arg_to_number(option_name: &str, value_as_string: &str) -> Result<usize, Box<dyn Error>> {
+fn convert_arg_to_number(
+    option_name: &str,
+    value_as_string: &str,
+) -> Result<usize, Box<dyn Error>> {
     match value_as_string.parse::<usize>() {
         Ok(val) => Ok(val),
         _ => Err(From::from(format!(

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -33,7 +33,7 @@ pub struct MatcherIO<'a> {
 impl<'a> MatcherIO<'a> {
     pub fn new(deps: &'a dyn Dependencies<'a>) -> MatcherIO<'a> {
         MatcherIO {
-            deps: deps,
+            deps,
             should_skip_dir: false,
         }
     }
@@ -66,7 +66,7 @@ pub trait Matcher {
     /// collection of sub-Matchers.
     fn has_side_effects(&self) -> bool {
         // most matchers don't have side-effects, so supply a default implementation.
-        return false;
+        false
     }
 
     /// Notification that find has finished processing a given directory.
@@ -213,7 +213,7 @@ fn build_matcher_tree(
                     return Err(From::from(format!("missing argument to {}", args[i])));
                 }
                 i += 1;
-                Some(name::NameMatcher::new_box(args[i].as_ref())?)
+                Some(name::NameMatcher::new_box(args[i])?)
             }
             "-iname" => {
                 if i >= args.len() - 1 {

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -484,7 +484,7 @@ mod tests {
             let mut config = Config::default();
 
             if let Err(e) = build_top_level_matcher(&[arg], &mut config) {
-                assert!(e.description().contains("expected an expression"));
+                assert!(e.to_string().contains("expected an expression"));
             } else {
                 panic!("parsing arugment lists that end in -not should fail");
             }
@@ -521,8 +521,8 @@ mod tests {
             let mut config = Config::default();
 
             if let Err(e) = build_top_level_matcher(&[arg], &mut config) {
-                assert!(e.description().contains("missing argument to"));
-                assert!(e.description().contains(arg));
+                assert!(e.to_string().contains("missing argument to"));
+                assert!(e.to_string().contains(arg));
             } else {
                 panic!("parsing arugment lists that end in -not should fail");
             }
@@ -535,7 +535,7 @@ mod tests {
             let mut config = Config::default();
 
             if let Err(e) = build_top_level_matcher(&[arg, "-true"], &mut config) {
-                assert!(e.description().contains("you have used a binary operator"));
+                assert!(e.to_string().contains("you have used a binary operator"));
             } else {
                 panic!("parsing arugment list that begins with -or should fail");
             }
@@ -548,7 +548,7 @@ mod tests {
             let mut config = Config::default();
 
             if let Err(e) = build_top_level_matcher(&["-true", arg], &mut config) {
-                assert!(e.description().contains("expected an expression"));
+                assert!(e.to_string().contains("expected an expression"));
             } else {
                 panic!("parsing arugment list that ends with -or should fail");
             }
@@ -560,7 +560,7 @@ mod tests {
         let mut config = Config::default();
 
         if let Err(e) = build_top_level_matcher(&["-a", "-true"], &mut config) {
-            assert!(e.description().contains("you have used a binary operator"));
+            assert!(e.to_string().contains("you have used a binary operator"));
         } else {
             panic!("parsing arugment list that begins with -a should fail");
         }
@@ -571,7 +571,7 @@ mod tests {
         let mut config = Config::default();
 
         if let Err(e) = build_top_level_matcher(&["-true", "-a"], &mut config) {
-            assert!(e.description().contains("expected an expression"));
+            assert!(e.to_string().contains("expected an expression"));
         } else {
             panic!("parsing arugment list that ends with -or should fail");
         }
@@ -673,13 +673,13 @@ mod tests {
         let mut config = Config::default();
 
         if let Err(e) = build_top_level_matcher(&[",", "-true"], &mut config) {
-            assert!(e.description().contains("you have used a binary operator"));
+            assert!(e.to_string().contains("you have used a binary operator"));
         } else {
             panic!("parsing arugment list that begins with , should fail");
         }
 
         if let Err(e) = build_top_level_matcher(&["-true", "-o", ",", "-true"], &mut config) {
-            assert!(e.description().contains("you have used a binary operator"));
+            assert!(e.to_string().contains("you have used a binary operator"));
         } else {
             panic!("parsing arugment list that contains '-o  ,' should fail");
         }
@@ -690,7 +690,7 @@ mod tests {
         let mut config = Config::default();
 
         if let Err(e) = build_top_level_matcher(&["-true", ","], &mut config) {
-            assert!(e.description().contains("expected an expression"));
+            assert!(e.to_string().contains("expected an expression"));
         } else {
             panic!("parsing arugment list that ends with , should fail");
         }
@@ -701,7 +701,7 @@ mod tests {
         let mut config = Config::default();
 
         if let Err(e) = build_top_level_matcher(&["-true", "("], &mut config) {
-            assert!(e.description().contains("I was expecting to find a ')'"));
+            assert!(e.to_string().contains("I was expecting to find a ')'"));
         } else {
             panic!("parsing arugment list with not enough closing brackets should fail");
         }
@@ -712,7 +712,7 @@ mod tests {
         let mut config = Config::default();
 
         if let Err(e) = build_top_level_matcher(&["-true", "(", ")", ")"], &mut config) {
-            assert!(e.description().contains("too many ')'"));
+            assert!(e.to_string().contains("too many ')'"));
         } else {
             panic!("parsing arugment list with too many closing brackets should fail");
         }
@@ -909,7 +909,7 @@ mod tests {
 
         if let Err(e) = build_top_level_matcher(&["-ctime", "-123."], &mut config) {
             assert!(
-                e.description().contains("Expected a decimal integer"),
+                e.to_string().contains("Expected a decimal integer"),
                 "bad description: {}",
                 e
             );
@@ -923,19 +923,19 @@ mod tests {
         let mut config = Config::default();
 
         if let Err(e) = build_top_level_matcher(&["-exec"], &mut config) {
-            assert!(e.description().contains("missing argument"));
+            assert!(e.to_string().contains("missing argument"));
         } else {
             panic!("parsing argument list with exec and no executable or semi-colon should fail");
         }
 
         if let Err(e) = build_top_level_matcher(&["-exec", ";"], &mut config) {
-            assert!(e.description().contains("missing argument"));
+            assert!(e.to_string().contains("missing argument"));
         } else {
             panic!("parsing argument list with exec and no executable should fail");
         }
 
         if let Err(e) = build_top_level_matcher(&["-exec", "foo"], &mut config) {
-            assert!(e.description().contains("missing argument"));
+            assert!(e.to_string().contains("missing argument"));
         } else {
             panic!("parsing argument list with exec and no executable should fail");
         }
@@ -973,13 +973,13 @@ mod tests {
     fn build_top_level_matcher_perm_bad() {
         let mut config = Config::default();
         if let Err(e) = build_top_level_matcher(&["-perm", "foo"], &mut config) {
-            assert!(e.description().contains("invalid mode"));
+            assert!(e.to_string().contains("invalid mode"));
         } else {
             panic!("-perm with bad mode pattern should fail");
         }
 
         if let Err(e) = build_top_level_matcher(&["-perm"], &mut config) {
-            assert!(e.description().contains("missing argument"));
+            assert!(e.to_string().contains("missing argument"));
         } else {
             panic!("-perm with no mode pattern should fail");
         }
@@ -990,13 +990,13 @@ mod tests {
     fn build_top_level_matcher_perm_not_unix() {
         let mut config = Config::default();
         if let Err(e) = build_top_level_matcher(&["-perm", "444"], &mut config) {
-            assert!(e.description().contains("not available"));
+            assert!(e.to_string().contains("not available"));
         } else {
             panic!("-perm on non-unix systems shouldn't be available");
         }
 
         if let Err(e) = build_top_level_matcher(&["-perm"], &mut config) {
-            assert!(e.description().contains("missing argument"));
+            assert!(e.to_string().contains("missing argument"));
         } else {
             panic!("-perm with no mode pattern should fail");
         }

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -423,7 +423,7 @@ mod tests {
                 return dir_entry;
             }
         }
-        panic!("Couldn't find {} in {}", directory, filename);
+        panic!("Couldn't find {} in {}", filename, directory);
     }
 
     #[test]

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -229,7 +229,7 @@ fn build_matcher_tree(
             "-delete" => {
                 // -delete implicitly requires -depth
                 config.depth_first = true;
-                Some(delete::DeleteMatcher::new_box())
+                Some(delete::DeleteMatcher::new_box()?)
             }
             "-newer" => {
                 if i >= args.len() - 1 {

--- a/src/find/matchers/perm.rs
+++ b/src/find/matchers/perm.rs
@@ -49,8 +49,8 @@ impl FromStr for ComparisonType {
 
 #[cfg(unix)]
 impl ComparisonType {
-    fn mode_bits_match(&self, pattern: u32, value: u32) -> bool {
-        match *self {
+    fn mode_bits_match(self, pattern: u32, value: u32) -> bool {
+        match self {
             ComparisonType::Exact => (0o7777 & value) == pattern,
             ComparisonType::AtLeast => (value & pattern) == pattern,
             ComparisonType::AnyOf => pattern == 0 || (value & pattern) > 0,
@@ -89,7 +89,7 @@ mod parsing {
                 state: ParserState::Beginning,
                 bit_pattern: 0,
                 comparison_type: ComparisonType::Exact,
-                string_pattern: string_pattern,
+                string_pattern,
                 category_bit_pattern: 0,
             }
         }
@@ -101,10 +101,10 @@ mod parsing {
             )))
         }
 
-        fn handle_char(&mut self, char: &char) -> Result<(), Box<dyn Error>> {
+        fn handle_char(&mut self, char: char) -> Result<(), Box<dyn Error>> {
             if let ParserState::Beginning = self.state {};
 
-            match *char {
+            match char {
                 '-' => {
                     if let ParserState::Beginning = self.state {
                         self.comparison_type = ComparisonType::AtLeast;
@@ -253,7 +253,7 @@ mod parsing {
         // no: so we've got a /u=rw,g=r form instead (or an invalid string).
         let mut p = Parser::new(string_value);
         for c in string_value.chars() {
-            p.handle_char(&c)?;
+            p.handle_char(c)?;
         }
         Ok((p.bit_pattern, p.comparison_type))
     }
@@ -274,7 +274,7 @@ impl PermMatcher {
         let (bit_pattern, comparison_type) = parsing::parse(pattern)?;
         Ok(PermMatcher {
             pattern: bit_pattern,
-            comparison_type: comparison_type,
+            comparison_type,
         })
     }
 

--- a/src/find/matchers/prune.rs
+++ b/src/find/matchers/prune.rs
@@ -46,5 +46,4 @@ mod tests {
         assert!(matcher.matches(&dir, &mut matcher_io));
         assert!(matcher_io.should_skip_current_dir());
     }
-
 }

--- a/src/find/matchers/size.rs
+++ b/src/find/matchers/size.rs
@@ -157,7 +157,7 @@ mod tests {
     fn size_matcher_bad_unit() {
         if let Err(e) = SizeMatcher::new(ComparableValue::EqualTo(2), "xyz") {
             assert!(
-                e.description().contains("Invalid suffix") && e.description().contains("xyz"),
+                e.to_string().contains("Invalid suffix") && e.to_string().contains("xyz"),
                 "bad description: {}",
                 e
             );

--- a/src/find/matchers/size.rs
+++ b/src/find/matchers/size.rs
@@ -78,7 +78,7 @@ impl SizeMatcher {
     ) -> Result<SizeMatcher, Box<dyn Error>> {
         Ok(SizeMatcher {
             unit: suffix_string.parse()?,
-            value_to_match: value_to_match,
+            value_to_match,
         })
     }
 

--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use std;
 use std::error::Error;
 use std::fs::{self, Metadata};
 use std::io::{stderr, Write};
@@ -135,8 +134,8 @@ impl FileTimeMatcher {
 
     pub fn new(file_time_type: FileTimeType, days: ComparableValue) -> FileTimeMatcher {
         FileTimeMatcher {
-            file_time_type: file_time_type,
-            days: days,
+            file_time_type,
+            days,
         }
     }
 

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -83,5 +83,4 @@ mod tests {
         let result = TypeMatcher::new(&"xxx".to_string());
         assert!(result.is_err());
     }
-
 }

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -164,8 +164,9 @@ Early alpha implementation. Currently the only expressions supported are
  -name case-sensitive_filename_pattern
  -iname case-insensitive_filename_pattern
  -type type_char
-    currently type_char can only be f (for file) or d (for directory) 
+    currently type_char can only be f (for file) or d (for directory)
  -size [+-]N[bcwkMG]
+ -delete
  -prune
  -not
  -a
@@ -183,8 +184,8 @@ Early alpha implementation. Currently the only expressions supported are
  -perm [-/]{{octal|u=rwx,go=w}}
  -newer path_to_file
  -exec[dir] executable [args] [{{}}] [more args] ;
- -sorted 
-    a non-standard extension that sorts directory contents by name before 
+ -sorted
+    a non-standard extension that sorts directory contents by name before
     processing them. Less efficient, but allows for deterministic output.
 "
     );

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -55,6 +55,12 @@ impl StandardDependencies {
     }
 }
 
+impl Default for StandardDependencies {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> Dependencies<'a> for StandardDependencies {
     fn get_output(&'a self) -> &'a RefCell<dyn Write> {
         self.output.as_ref()
@@ -91,12 +97,13 @@ fn parse_args(args: &[&str]) -> Result<ParsedInfo, Box<dyn Error>> {
     }
     let matcher = matchers::build_top_level_matcher(&args[i..], &mut config)?;
     Ok(ParsedInfo {
-        matcher: matcher,
-        paths: paths,
-        config: config,
+        matcher,
+        paths,
+        config,
     })
 }
 
+#[allow(clippy::borrowed_box)] // FIXME?
 fn process_dir<'a>(
     dir: &str,
     config: &Config,

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -118,9 +118,7 @@ fn process_dir<'a>(
     loop {
         match it.next() {
             None => break,
-            Some(Err(err)) => {
-                writeln!(&mut stderr(), "Error: {}: {}", dir, err.description()).unwrap()
-            }
+            Some(Err(err)) => writeln!(&mut stderr(), "Error: {}: {}", dir, err).unwrap(),
             Some(Ok(entry)) => {
                 let mut matcher_io = matchers::MatcherIO::new(deps);
                 if matcher.matches(&entry, &mut matcher_io) {
@@ -265,7 +263,7 @@ mod tests {
     }
 
     impl<'a> Dependencies<'a> for FakeDependencies {
-        fn get_output(&'a self) -> &'a RefCell<Write> {
+        fn get_output(&'a self) -> &'a RefCell<dyn Write> {
             &self.output
         }
 
@@ -286,7 +284,7 @@ mod tests {
         //
         let result = super::parse_args(&["-asdadsafsfsadcs"]);
         if let Err(e) = result {
-            assert_eq!(e.description(), "Unrecognized flag: '-asdadsafsfsadcs'");
+            assert_eq!(e.to_string(), "Unrecognized flag: '-asdadsafsfsadcs'");
         } else {
             panic!("parse_args should have returned an error");
         }

--- a/src/testing/commandline/main.rs
+++ b/src/testing/commandline/main.rs
@@ -44,8 +44,10 @@ fn main() {
     if args.len() < 2 || args[1] == "-h" || args[1] == "--help" {
         usage();
     }
-    let mut config = Config::default();
-    config.destination_dir = args[1].clone();
+    let mut config = Config {
+        destination_dir: args[1].clone(),
+        ..Default::default()
+    };
     for arg in &args[2..] {
         if arg.starts_with("--") {
             match arg.as_ref() {

--- a/tests/common/test_helpers.rs
+++ b/tests/common/test_helpers.rs
@@ -44,7 +44,7 @@ impl<'a> FakeDependencies {
 }
 
 impl<'a> Dependencies<'a> for FakeDependencies {
-    fn get_output(&'a self) -> &'a RefCell<Write> {
+    fn get_output(&'a self) -> &'a RefCell<dyn Write> {
         &self.output
     }
 

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Chad Williamson
+// Copyright 2021 Chad Williamson <chad@dahc.us>
 //
 // Use of this source code is governed by an MIT-syle license that can be
 // found in the LICENSE file or at https://opensource.org/licenses/MIT.

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -23,7 +23,7 @@ fn no_args() {
         .assert()
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout(predicate::str::contains("\n./test_data\n"));
+        .stdout(predicate::str::contains("test_data"));
 }
 
 #[serial(working_dir)]
@@ -35,7 +35,7 @@ fn two_matchers_both_match() {
         .assert()
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout(predicate::str::similar("./test_data\n"));
+        .stdout(predicate::str::contains("test_data"));
 }
 
 #[serial(working_dir)]

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -100,13 +100,14 @@ fn delete_on_dot_dir() {
     let original_dir = env::current_dir().unwrap();
     env::set_current_dir(&temp_dir.path()).expect("working dir changed");
 
+    // "." should be matched (confirmed by the print), but not deleted.
     Command::cargo_bin("find")
         .expect("found binary")
-        .args(&[".", "-delete"])
+        .args(&[".", "-delete", "-print"])
         .assert()
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout(predicate::str::is_empty());
+        .stdout(predicate::str::similar(".\n"));
 
     env::set_current_dir(original_dir).expect("restored original working dir");
 

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -1,0 +1,114 @@
+// Copyright 2021 Chad Williamson
+//
+// Use of this source code is governed by an MIT-syle license that can be
+// found in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+// This file contains integration tests for the find command.
+//
+// Note: the `serial` macro is used on tests that make assumptions about the
+// working directory, since we have at least one test that needs to change it.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use std::env;
+use std::fs::File;
+use tempdir::TempDir;
+
+#[serial(working_dir)]
+#[test]
+fn no_args() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("\n./test_data\n"));
+}
+
+#[serial(working_dir)]
+#[test]
+fn two_matchers_both_match() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(&["-type", "d", "-name", "test_data"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::similar("./test_data\n"));
+}
+
+#[serial(working_dir)]
+#[test]
+fn two_matchers_one_matches() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(&["-type", "f", "-name", "test_data"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn matcher_with_side_effects_at_end() {
+    let temp_dir = TempDir::new("find_cmd_").expect("made temp dir");
+    let temp_dir_path = temp_dir.path().to_string_lossy();
+    let test_file = temp_dir.path().join("test");
+    File::create(&test_file).expect("created test file");
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(&[&temp_dir_path, "-name", "test", "-delete"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::is_empty());
+
+    assert!(!test_file.exists(), "test file should be deleted");
+    assert!(temp_dir.path().exists(), "temp dir should NOT be deleted");
+}
+
+#[test]
+fn matcher_with_side_effects_in_front() {
+    let temp_dir = TempDir::new("find_cmd_").expect("made temp dir");
+    let temp_dir_path = temp_dir.path().to_string_lossy();
+    let test_file = temp_dir.path().join("test");
+    File::create(&test_file).expect("created test file");
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(&[&temp_dir_path, "-delete", "-name", "test"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::is_empty());
+
+    assert!(!test_file.exists(), "test file should be deleted");
+    assert!(!temp_dir.path().exists(), "temp dir should also be deleted");
+}
+
+// This could be covered by a unit test in principle... in practice, changing
+// the working dir can't be done safely in unit tests unless `--test-threads=1`
+// or `serial` goes everywhere, and it doesn't seem possible to get an
+// appropriate `walkdir::DirEntry` for "." without actually changing dirs
+// (or risking deletion of the repo itself).
+#[serial(working_dir)]
+#[test]
+fn delete_on_dot_dir() {
+    let temp_dir = TempDir::new("find_cmd_").expect("made temp dir");
+    let original_dir = env::current_dir().unwrap();
+    env::set_current_dir(&temp_dir.path()).expect("working dir changed");
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(&[".", "-delete"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::is_empty());
+
+    env::set_current_dir(original_dir).expect("restored original working dir");
+
+    assert!(temp_dir.path().exists(), "temp dir should still exist");
+}


### PR DESCRIPTION
This takes @Arcterus's implementation of -delete and fixes a few issues in hopes of getting it added.

The most significant change other than the tests is a bit of rework on skipping the working dir. The existing code tried to skip the working dir in general, which isn't quite right. Only a literal "." is supposed to be skipped, which is actually simpler to do.

Safely testing that behavior was a little tricky from the unit test perspective, so I took the liberty of adding some general integration tests, which I think provide some value on their own and are an easier context from which to test the dot thing.

Also included are a bunch of trivial compiler warning fixes (was rather noisy).