### PR TITLE
Fix clippy errors in src/find/mod.rs

### DIFF
--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -109,7 +109,7 @@ fn process_dir<'a>(
     config: &Config,
     deps: &'a dyn Dependencies<'a>,
     matcher: &Box<dyn matchers::Matcher>,
-) -> Result<u64, Box<dyn Error>> {
+) -> u64 {
     let mut found_count: u64 = 0;
     let mut walkdir = WalkDir::new(dir)
         .contents_first(config.depth_first)
@@ -137,7 +137,7 @@ fn process_dir<'a>(
             }
         }
     }
-    Ok(found_count)
+    found_count
 }
 
 fn do_find<'a>(args: &[&str], deps: &'a dyn Dependencies<'a>) -> Result<u64, Box<dyn Error>> {
@@ -153,7 +153,7 @@ fn do_find<'a>(args: &[&str], deps: &'a dyn Dependencies<'a>) -> Result<u64, Box
             &paths_and_matcher.config,
             deps,
             &paths_and_matcher.matcher,
-        )?;
+        );
     }
     Ok(found_count)
 }

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -103,12 +103,11 @@ fn parse_args(args: &[&str]) -> Result<ParsedInfo, Box<dyn Error>> {
     })
 }
 
-#[allow(clippy::borrowed_box)] // FIXME?
 fn process_dir<'a>(
     dir: &str,
     config: &Config,
     deps: &'a dyn Dependencies<'a>,
-    matcher: &Box<dyn matchers::Matcher>,
+    matcher: &dyn matchers::Matcher,
 ) -> u64 {
     let mut found_count: u64 = 0;
     let mut walkdir = WalkDir::new(dir)
@@ -152,7 +151,7 @@ fn do_find<'a>(args: &[&str], deps: &'a dyn Dependencies<'a>) -> Result<u64, Box
             &path,
             &paths_and_matcher.config,
             deps,
-            &paths_and_matcher.matcher,
+            &*paths_and_matcher.matcher,
         );
     }
     Ok(found_count)


### PR DESCRIPTION
- Error `clippy::unnecessary-wraps` that is failing ci
- Error `clippy::borrowed-box` that was ignored