### PR TITLE
Add support for regex matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      # For bindgen: https://github.com/rust-lang/rust-bindgen/issues/1797
+      - uses: KyleMayes/install-llvm-action@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          version: "11.0"
+          directory: ${{ runner.temp }}/llvm
+      - run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+        if: matrix.os == 'windows-latest'
+
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -33,6 +43,16 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      # For bindgen: https://github.com/rust-lang/rust-bindgen/issues/1797
+      - uses: KyleMayes/install-llvm-action@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          version: "11.0"
+          directory: ${{ runner.temp }}/llvm
+      - run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+        if: matrix.os == 'windows-latest'
+
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bindgen"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +98,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +129,17 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -133,6 +182,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +224,7 @@ dependencies = [
  "filetime",
  "glob",
  "once_cell",
+ "onig",
  "predicates",
  "regex",
  "serial_test",
@@ -204,6 +267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,10 +297,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+
+[[package]]
+name = "libloading"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "lock_api"
@@ -243,10 +328,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -286,6 +390,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
+name = "onig"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ddfe2c93bb389eea6e6d713306880c7f6dcc99a75b659ce145d962c861b225"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "libc",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd3eee045c84695b53b20255bb7317063df090b68e18bfac0abb6c39cf7f33e"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "os_display"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +445,18 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "predicates"
@@ -427,6 +566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "same-file"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
 name = "smallvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +649,15 @@ dependencies = [
  "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+dependencies = [
+ "wincolor",
 ]
 
 [[package]]
@@ -573,6 +733,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +756,15 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -631,3 +806,13 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincolor"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df6193e795abf9e39a5e4926d13ed002dbeca334fd7299398c372be918fd04"
+dependencies = [
+ "winapi",
+ "winapi-util",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ walkdir = "2.3"
 tempfile = "3"
 regex = "1.5"
 once_cell = "1.9"
+onig = "6.3"
 uucore = { git = "https://github.com/uutils/coreutils", features = ["entries", "fs", "fsext"] }
 
 [dev-dependencies]

--- a/src/find/matchers/regex.rs
+++ b/src/find/matchers/regex.rs
@@ -1,0 +1,241 @@
+// Copyright 2022 Collabora, Ltd.
+//
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use std::{error::Error, fmt, str::FromStr};
+
+use onig::{Regex, RegexOptions, Syntax};
+
+use super::Matcher;
+
+#[derive(Debug)]
+pub struct ParseRegexTypeError(String);
+
+impl Error for ParseRegexTypeError {}
+
+impl fmt::Display for ParseRegexTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Invalid regex type: {} (must be one of {})",
+            self.0,
+            RegexType::VALUES
+                .iter()
+                .map(|t| format!("'{}'", t))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegexType {
+    Emacs,
+    Grep,
+    PosixBasic,
+    PosixExtended,
+}
+
+impl RegexType {
+    pub const VALUES: &'static [RegexType] = &[
+        RegexType::Emacs,
+        RegexType::Grep,
+        RegexType::PosixBasic,
+        RegexType::PosixExtended,
+    ];
+}
+
+impl fmt::Display for RegexType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RegexType::Emacs => write!(f, "emacs"),
+            RegexType::Grep => write!(f, "grep"),
+            RegexType::PosixBasic => write!(f, "posix-basic"),
+            RegexType::PosixExtended => write!(f, "posix-extended"),
+        }
+    }
+}
+
+impl FromStr for RegexType {
+    type Err = ParseRegexTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "emacs" => Ok(RegexType::Emacs),
+            "grep" => Ok(RegexType::Grep),
+            "posix-basic" => Ok(RegexType::PosixBasic),
+            "posix-extended" => Ok(RegexType::PosixExtended),
+            _ => Err(ParseRegexTypeError(s.to_owned())),
+        }
+    }
+}
+
+impl Default for RegexType {
+    fn default() -> Self {
+        RegexType::Emacs
+    }
+}
+
+pub struct RegexMatcher {
+    regex: Regex,
+}
+
+impl RegexMatcher {
+    pub fn new(
+        regex_type: RegexType,
+        pattern: &str,
+        ignore_case: bool,
+    ) -> Result<RegexMatcher, Box<dyn Error>> {
+        let syntax = match regex_type {
+            RegexType::Emacs => Syntax::emacs(),
+            RegexType::Grep => Syntax::grep(),
+            RegexType::PosixBasic => Syntax::posix_basic(),
+            RegexType::PosixExtended => Syntax::posix_extended(),
+        };
+
+        let regex = Regex::with_options(
+            pattern,
+            if ignore_case {
+                RegexOptions::REGEX_OPTION_IGNORECASE
+            } else {
+                RegexOptions::REGEX_OPTION_NONE
+            },
+            syntax,
+        )?;
+        Ok(RegexMatcher { regex })
+    }
+
+    pub fn new_box(
+        regex_type: RegexType,
+        pattern: &str,
+        ignore_case: bool,
+    ) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
+        Ok(Box::new(RegexMatcher::new(
+            regex_type,
+            pattern,
+            ignore_case,
+        )?))
+    }
+}
+
+impl Matcher for RegexMatcher {
+    fn matches(&self, file_info: &walkdir::DirEntry, _: &mut super::MatcherIO) -> bool {
+        self.regex
+            .is_match(file_info.path().to_string_lossy().as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::find::matchers::tests::get_dir_entry_for;
+    use crate::find::matchers::Matcher;
+    use crate::find::tests::FakeDependencies;
+
+    const POSIX_BASIC_INTERVALS_RE: &str = r".*/ab\{1,3\}c";
+    const POSIX_EXTENDED_INTERVALS_RE: &str = r".*/ab{1,3}c";
+    const EMACS_AND_POSIX_EXTENDED_KLEENE_PLUS: &str = r".*/ab+c";
+
+    // Variants of fix_up_slashes that properly escape the forward slashes for
+    // being in a regex.
+    #[cfg(windows)]
+    fn fix_up_regex_slashes(re: &str) -> String {
+        re.replace("/", "\\\\")
+    }
+
+    #[cfg(not(windows))]
+    fn fix_up_regex_slashes(re: &str) -> String {
+        re.to_owned()
+    }
+
+    #[test]
+    fn case_sensitive_matching() {
+        let abbbc = get_dir_entry_for("test_data/simple", "abbbc");
+        let matcher =
+            RegexMatcher::new(RegexType::Emacs, &fix_up_regex_slashes(".*/ab.BC"), false).unwrap();
+        let deps = FakeDependencies::new();
+        assert!(!matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        let abbbc = get_dir_entry_for("test_data/simple", "abbbc");
+        let matcher =
+            RegexMatcher::new(RegexType::Emacs, &fix_up_regex_slashes(".*/ab.BC"), true).unwrap();
+        let deps = FakeDependencies::new();
+        assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+    }
+
+    #[test]
+    fn emacs_regex() {
+        // Emacs syntax is mostly the same as POSIX extended but with escaped
+        // brace intervals.
+        let abbbc = get_dir_entry_for("test_data/simple", "abbbc");
+
+        let matcher = RegexMatcher::new(
+            RegexType::Emacs,
+            &fix_up_regex_slashes(EMACS_AND_POSIX_EXTENDED_KLEENE_PLUS),
+            true,
+        )
+        .unwrap();
+        let deps = FakeDependencies::new();
+        assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+
+        let matcher = RegexMatcher::new(
+            RegexType::Emacs,
+            &fix_up_regex_slashes(POSIX_EXTENDED_INTERVALS_RE),
+            true,
+        )
+        .unwrap();
+        let deps = FakeDependencies::new();
+        assert!(!matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+    }
+
+    #[test]
+    fn posix_basic_regex() {
+        let abbbc = get_dir_entry_for("test_data/simple", "abbbc");
+
+        let matcher = RegexMatcher::new(
+            RegexType::PosixBasic,
+            &fix_up_regex_slashes(POSIX_BASIC_INTERVALS_RE),
+            true,
+        )
+        .unwrap();
+        let deps = FakeDependencies::new();
+        assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+
+        let matcher = RegexMatcher::new(
+            RegexType::PosixBasic,
+            &fix_up_regex_slashes(POSIX_EXTENDED_INTERVALS_RE),
+            true,
+        )
+        .unwrap();
+        let deps = FakeDependencies::new();
+        assert!(!matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+    }
+
+    #[test]
+    fn posix_extended_regex() {
+        let abbbc = get_dir_entry_for("test_data/simple", "abbbc");
+
+        let matcher = RegexMatcher::new(
+            RegexType::PosixExtended,
+            &fix_up_regex_slashes(POSIX_EXTENDED_INTERVALS_RE),
+            true,
+        )
+        .unwrap();
+        let deps = FakeDependencies::new();
+        assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+
+        let matcher = RegexMatcher::new(
+            RegexType::PosixExtended,
+            &fix_up_regex_slashes(POSIX_BASIC_INTERVALS_RE),
+            true,
+        )
+        .unwrap();
+        let deps = FakeDependencies::new();
+        assert!(!matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+    }
+}

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -175,6 +175,9 @@ Early alpha implementation. Currently the only expressions supported are
  -printf
  -name case-sensitive_filename_pattern
  -iname case-insensitive_filename_pattern
+ -regextype type
+ -regex pattern
+ -iregex pattern
  -type type_char
     currently type_char can only be f (for file) or d (for directory)
  -size [+-]N[bcwkMG]


### PR DESCRIPTION
This adds support for -regextype, -regex, and -iregex, using Oniguruma
to implement support for the Emacs, grep, POSIX basic, and POSIX
extended regex types.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>

<hr>

Meta note: I'm not sure if it would be preferred to have this behind a feature, since oniguruma *is* a C dependency, or if `regex` should be removed instead due to functionality overlap.