### PR TITLE
Add initial parts of automated compatibility tests

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,0 +1,141 @@
+on: [push, pull_request]
+
+name: GNU findutils compatibility tests
+
+jobs:
+  gnu-tests:
+    name: Run GNU findutils tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout findutils
+      uses: actions/checkout@v2
+      with:
+        path: findutils
+    - name: Checkout GNU findutils
+      uses: actions/checkout@v2
+      with:
+        repository: gnu-mirror-unofficial/findutils
+        path: findutils.gnu
+        ref: 5768a03ddfb5e18b1682e339d6cdd24ff721c510
+        submodules: true
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Install dependencies
+      shell: bash
+      run: |
+        # Enable sources & install dependencies
+        sudo find /etc/apt/sources.list* -type f -exec sed -i 'p; s/^deb /deb-src /' '{}' +
+        sudo apt-get update
+        sudo apt-get build-dep findutils
+    - name: Run GNU tests
+      shell: bash
+      run: |
+        cd findutils
+        bash util/build-gnu.sh ||:
+    - name: Extract testing info
+      shell: bash
+      run: |
+        LOG_FILE=findutils.gnu/tests/test-suite.log
+        if test -f "$LOG_FILE"; then
+          TOTAL=$(sed -n "s/.*# TOTAL: \(.*\)/\1/p"  "$LOG_FILE"|tr -d '\r'|head -n1)
+          PASS=$(sed -n "s/.*# PASS: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
+          SKIP=$(sed -n "s/.*# SKIP: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
+          FAIL=$(sed -n "s/.*# FAIL: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
+          XPASS=$(sed -n "s/.*# XPASS: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
+          ERROR=$(sed -n "s/.*# ERROR: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
+          if [[ "$TOTAL" -eq 0 || "$TOTAL" -eq 1 ]]; then
+              echo "Error in the execution, failing early"
+              exit 1
+          fi
+          output="GNU tests summary = TOTAL: $TOTAL / PASS: $PASS / FAIL: $FAIL / ERROR: $ERROR"
+          echo "${output}"
+          if [[ "$FAIL" -gt 0 || "$ERROR" -gt 0 ]]; then echo "::warning ::${output}" ; fi
+          jq -n \
+                --arg date "$(date --rfc-email)" \
+                --arg sha "$GITHUB_SHA" \
+                --arg total "$TOTAL" \
+                --arg pass "$PASS" \
+                --arg skip "$SKIP" \
+                --arg fail "$FAIL" \
+                --arg xpass "$XPASS" \
+                --arg error "$ERROR" \
+                '{($date): { sha: $sha, total: $total, pass: $pass, skip: $skip, fail: $fail, xpass: $xpass, error: $error, }}' > gnu-result.json
+        else
+          echo "::error ::Failed to get summary of test results"
+        fi
+    - uses: actions/upload-artifact@v2
+      with:
+        name: gnu-test-report
+        path: findutils.gnu/tests/**/*.log
+    - uses: actions/upload-artifact@v2
+      with:
+        name: gnu-result
+        path: gnu-result.json
+
+  bfs-tests:
+    name: Run BFS tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout findutils
+      uses: actions/checkout@v2
+      with:
+        path: findutils
+    - name: Checkout BFS
+      uses: actions/checkout@v2
+      with:
+        repository: tavianator/bfs
+        path: bfs
+        ref: '2.3.1'
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Install dependencies
+      shell: bash
+      run: |
+        # Enable sources & install dependencies
+        sudo find /etc/apt/sources.list* -type f -exec sed -i 'p; s/^deb /deb-src /' '{}' +
+        sudo apt-get update
+        sudo apt-get build-dep bfs
+    - name: Run BFS tests
+      shell: bash
+      run: |
+        cd findutils
+        bash util/build-bfs.sh ||:
+    - name: Extract testing info
+      shell: bash
+      run: |
+        LOG_FILE=bfs/tests.log
+        if test -f "$LOG_FILE"; then
+          PASS=$(sed -n "s/^tests passed: \(.*\)/\1/p" "$LOG_FILE"|head -n1)
+          FAIL=$(sed -n "s/^tests failed: \(.*\)/\1/p" "$LOG_FILE"|head -n1)
+          TOTAL=$(($PASS + $FAIL))
+          if [[ "$TOTAL" -eq 0 || "$TOTAL" -eq 1 ]]; then
+              echo "Error in the execution, failing early"
+              exit 1
+          fi
+          output="BFS tests summary = TOTAL: $TOTAL / PASS: $PASS / FAIL: $FAIL"
+          echo "${output}"
+          if [[ "$FAIL" -gt 0 || "$ERROR" -gt 0 ]]; then echo "::warning ::${output}" ; fi
+          jq -n \
+                --arg date "$(date --rfc-email)" \
+                --arg sha "$GITHUB_SHA" \
+                --arg total "$TOTAL" \
+                --arg pass "$PASS" \
+                --arg fail "$FAIL" \
+                '{($date): { sha: $sha, total: $total, pass: $pass, fail: $fail, }}' > bfs-result.json
+        else
+          echo "::error ::Failed to get summary of test results"
+        fi
+    - uses: actions/upload-artifact@v2
+      with:
+        name: bfs-test-report
+        path: bfs/tests.log
+    - uses: actions/upload-artifact@v2
+      with:
+        name: bfs-result
+        path: bfs-result.json

--- a/util/build-bfs.sh
+++ b/util/build-bfs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 if ! test -d ../bfs; then
     echo "Could not find ../bfs"
@@ -20,4 +20,4 @@ if test "$#" -eq 0; then
     set -- --verbose --gnu
 fi
 
-./tests.sh --bfs="$FIND" "$@"
+./tests.sh --bfs="$FIND" "$@" | tee tests.log


### PR DESCRIPTION
This is the first half of the needed changes to set up automated
compatibility tests against GNU findutils and bfs, handling the uploads
of the build logs and JSON results. The workflow itself is heavily based
on the one from uutils/coreutils:

https://github.com/uutils/coreutils/blob/main/.github/workflows/GnuTests.yml

but with various cleanups & tweaks to better suit findutils.

This does *not* include the actual regression comparisons, because those
will only pass once archives of these files are up on the main branch.

Ref #128

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>

<hr>

Like the commit message mentions, this is the first half of the changes, because [the second half](https://github.com/uutils/findutils/compare/main...refi64:compat-tests-2?expand=1) needs already-built artifacts available. i.e., this needs to be merged *first*, then once CI passes, the second PR can be created and merged in.

I *have* tested these changes in a fork, you can see the results here:

- [Successful run](https://github.com/refi64/findutils-ci-tests/actions/runs/1730647383)
- [Run with regressions](https://github.com/refi64/findutils-ci-tests/actions/runs/1730679638) (I removed `-print` in this one)

I presume with this out of the way, I'll begin to see some of the open PRs merged? :wink: (Worth noting that, combining the current PRs with some offline work I have for `-L`, the amount of passing tests for BFS's suite goes up from the current 98 to 109!)