### PR TITLE
Implement support for following symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,8 +766,7 @@ dependencies = [
 [[package]]
 name = "walkdir"
 version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+source = "git+https://github.com/refi64/walkdir?branch=symlinks#f799a1c6c008ecd9810f124237470435707ea253"
 dependencies = [
  "same-file",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ predicates = "2"
 serial_test = "0.5"
 tempfile = "3"
 
+[patch.crates-io]
+walkdir = { git = "https://github.com/refi64/walkdir", branch = "symlinks" }
+
 [[bin]]
 name = "find"
 path = "src/find/main.rs"

--- a/tests/common/test_helpers.rs
+++ b/tests/common/test_helpers.rs
@@ -93,3 +93,65 @@ pub fn get_dir_entry_for(directory: &str, filename: &str) -> DirEntry {
     }
     panic!("Couldn't find {} in {}", directory, filename);
 }
+
+pub fn create_testing_symlinks() {
+    use std::io::ErrorKind;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
+    #[cfg(windows)]
+    use std::os::windows::fs::{symlink_dir, symlink_file};
+
+    #[cfg(unix)]
+    {
+        if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+        if let Err(e) = symlink("subdir", "test_data/links/link-d") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+        if let Err(e) = symlink("missing", "test_data/links/link-missing") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+        if let Err(e) = symlink("abbbc/x", "test_data/links/link-notdir") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+        if let Err(e) = symlink("link-loop", "test_data/links/link-loop") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+    }
+    #[cfg(windows)]
+    {
+        if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+        if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+        if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+        if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
+            if e.kind() != ErrorKind::AlreadyExists {
+                panic!("Failed to create sym link: {:?}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>

<hr>

Unfortunately, it wasn't possible to make work as needed without these two PRs to walkdir: https://github.com/BurntSushi/walkdir/pull/159 https://github.com/BurntSushi/walkdir/pull/160

However, it seems that PRs to walkdir have been stagnant since late 2020 / early 2021, so for the purpose of testing, I created a single branch on my fork with both PRs merged in, and Cargo.toml in here is pointing to that branch. I'm not quite sure how to handle this as a result, so this is in draft status. Any thoughts on how to handle this?