### PR TITLE
Update uucore to 0.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,15 +244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,9 +296,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libloading"
@@ -342,6 +333,28 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nom"
@@ -712,19 +725,21 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "uucore"
-version = "0.0.10"
-source = "git+https://github.com/uutils/coreutils#5c0adb26a57e594b369e4ffd0fe9f54b9d4efd20"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd62057d3da5f13c2b88c2824c75142f4a84234c9dea7b387b261970ac344e72"
 dependencies = [
  "clap",
  "dunce",
- "getopts",
  "libc",
+ "nix",
  "once_cell",
  "os_display",
  "termion",
  "time",
  "wild",
  "winapi",
+ "winapi-util",
 ]
 
 [[package]]
@@ -795,9 +810,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tempfile = "3"
 regex = "1.5"
 once_cell = "1.9"
 onig = "6.3"
-uucore = { git = "https://github.com/uutils/coreutils", features = ["entries", "fs", "fsext"] }
+uucore = { version = "0.0.12", features = ["entries", "fs", "fsext"] }
 
 [dev-dependencies]
 assert_cmd = "2"


### PR DESCRIPTION
This version includes the needed filesystem type detection fix.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>