### PR TITLE
Fix compat tests not using the latest workflow

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -78,6 +78,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: compat.yml
+        workflow_conclusion: completed
         name: gnu-result
         repo: uutils/findutils
         branch: main
@@ -86,6 +87,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: compat.yml
+        workflow_conclusion: completed
         name: gnu-test-report
         repo: uutils/findutils
         branch: main
@@ -179,6 +181,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: compat.yml
+        workflow_conclusion: completed
         name: bfs-result
         repo: uutils/findutils
         branch: main
@@ -187,6 +190,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: compat.yml
+        workflow_conclusion: completed
         name: bfs-test-report
         repo: uutils/findutils
         branch: main


### PR DESCRIPTION
By default, artifacts are only downloaded from the latest successful
workflow, meaning that, if the compat tests regressed, then it is
impossible to compare against the new current state. This isn't a
perfect solution, but I believe it should by far be "good enough" for
these purposes.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>