### PR TITLE
Avoid skipping the entire directory if a file hits -prune

### DIFF
--- a/src/find/matchers/prune.rs
+++ b/src/find/matchers/prune.rs
@@ -22,8 +22,11 @@ impl PruneMatcher {
 }
 
 impl Matcher for PruneMatcher {
-    fn matches(&self, _: &DirEntry, matcher_io: &mut MatcherIO) -> bool {
-        matcher_io.mark_current_dir_to_be_skipped();
+    fn matches(&self, file_info: &DirEntry, matcher_io: &mut MatcherIO) -> bool {
+        if file_info.file_type().is_dir() {
+            matcher_io.mark_current_dir_to_be_skipped();
+        }
+
         true
     }
 }
@@ -45,5 +48,17 @@ mod tests {
         let matcher = PruneMatcher::new();
         assert!(matcher.matches(&dir, &mut matcher_io));
         assert!(matcher_io.should_skip_current_dir());
+    }
+
+    #[test]
+    fn only_skips_directories() {
+        let abbbc = get_dir_entry_for("test_data/simple", "abbbc");
+        let deps = FakeDependencies::new();
+
+        let mut matcher_io = deps.new_matcher_io();
+        assert!(!matcher_io.should_skip_current_dir());
+        let matcher = PruneMatcher::new();
+        assert!(matcher.matches(&abbbc, &mut matcher_io));
+        assert!(!matcher_io.should_skip_current_dir());
     }
 }


### PR DESCRIPTION
This matches up with the behavior of GNU findutils, as documented in its
man page:

> **if the file is a directory**, do not descend into it

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>