### PR TITLE
ci: Update bfs testsuite to version 2.6

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -90,7 +90,7 @@ jobs:
       with:
         repository: tavianator/bfs
         path: bfs
-        ref: '2.4'
+        ref: '2.6'
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal

--- a/util/build-bfs.sh
+++ b/util/build-bfs.sh
@@ -13,15 +13,15 @@ cargo build --release
 FIND=$(readlink -f target/release/find)
 
 cd ..
-make -C bfs -j "$(nproc)" tests/mksock WITH_ONIGURUMA=
+make -C bfs -j "$(nproc)" bin/tests/mksock WITH_ONIGURUMA=
 
 # Run the GNU find compatibility tests by default
 if test "$#" -eq 0; then
-    set -- --verbose --gnu
+    set -- --verbose=tests --gnu --sudo
 fi
 
 LOG_FILE=bfs/tests.log
-./bfs/tests.sh --bfs="$FIND" "$@" | tee "$LOG_FILE" || :
+./bfs/tests/tests.sh --bfs="$FIND" "$@" | tee "$LOG_FILE" || :
 
 PASS=$(sed -n "s/^tests passed: \(.*\)/\1/p" "$LOG_FILE" | head -n1)
 SKIP=$(sed -n "s/^tests skipped: \(.*\)/\1/p" "$LOG_FILE" | head -n1)


### PR DESCRIPTION
The latest bfs properly groups the --sudo tests, so we can test things
that require root like -xdev.
