### PR TITLE
find: Don't swallow mkfifo errors in the tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "clap",
  "faccess",
  "filetime",
+ "nix 0.24.2",
  "once_cell",
  "onig",
  "predicates",
@@ -446,6 +447,18 @@ checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
  "cfg-if",
  "libc",
  "memoffset",
@@ -871,7 +884,7 @@ dependencies = [
  "clap",
  "dunce",
  "libc",
- "nix",
+ "nix 0.23.1",
  "once_cell",
  "os_display",
  "termion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ uucore = { version = "0.0.12", features = ["entries", "fs", "fsext", "mode"] }
 [dev-dependencies]
 assert_cmd = "2"
 filetime = "0.2"
+nix = "0.24"
 predicates = "2"
 serial_test = "0.8"
 tempfile = "3"

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -906,19 +906,16 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_printf_special_types() {
-        use std::os::unix::{net::UnixListener, prelude::OsStrExt};
+        use std::os::unix::net::UnixListener;
+
+        use nix::sys::stat::Mode;
 
         let temp_dir = Builder::new().prefix("example").tempdir().unwrap();
         let temp_dir_path = temp_dir.path().to_string_lossy();
 
         let fifo_name = "fifo";
         let fifo_path = temp_dir.path().join(fifo_name);
-        unsafe {
-            uucore::libc::mkfifo(
-                fifo_path.as_os_str().as_bytes().as_ptr() as *const i8,
-                0o644,
-            );
-        };
+        nix::unistd::mkfifo(&fifo_path, Mode::from_bits(0o644).unwrap()).unwrap();
 
         let socket_name = "socket";
         let socket_path = temp_dir.path().join(socket_name);


### PR DESCRIPTION
Use nix's version of mkfifo instead, which lets us easily access the
errors and then fail with more information than the FIFO mysteriously
not appearing.

Ref. #177.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>