### PR TITLE
implemented assert! for resolving warning panic!

### DIFF
--- a/src/find/matchers/lname.rs
+++ b/src/find/matchers/lname.rs
@@ -74,13 +74,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/src/find/matchers/lname.rs
+++ b/src/find/matchers/lname.rs
@@ -73,15 +73,19 @@ mod tests {
     fn create_file_link() {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
     }
 

--- a/src/find/matchers/lname.rs
+++ b/src/find/matchers/lname.rs
@@ -74,13 +74,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/src/find/matchers/lname.rs
+++ b/src/find/matchers/lname.rs
@@ -74,7 +74,7 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );
@@ -82,7 +82,7 @@ mod tests {
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );

--- a/src/find/matchers/lname.rs
+++ b/src/find/matchers/lname.rs
@@ -74,13 +74,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/src/find/matchers/lname.rs
+++ b/src/find/matchers/lname.rs
@@ -74,13 +74,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -48,13 +48,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -48,13 +48,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -48,13 +48,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -47,15 +47,19 @@ mod tests {
     fn create_file_link() {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
     }
 

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -48,7 +48,7 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );
@@ -56,7 +56,7 @@ mod tests {
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -48,13 +48,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -947,27 +947,27 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("link-loop", "test_data/links/link-loop") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         }
@@ -975,22 +975,22 @@ mod tests {
         {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         }

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -947,27 +947,27 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("link-loop", "test_data/links/link-loop") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         }
@@ -975,22 +975,22 @@ mod tests {
         {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         }

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -947,35 +947,35 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink("missing", "test_data/links/link-missing") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink("abbbc/x", "test_data/links/link-notdir") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink("link-loop", "test_data/links/link-loop") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
@@ -985,28 +985,28 @@ mod tests {
         {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -947,27 +947,27 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("link-loop", "test_data/links/link-loop") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         }
@@ -975,22 +975,22 @@ mod tests {
         {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         }

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -947,27 +947,27 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("link-loop", "test_data/links/link-loop") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         }
@@ -975,22 +975,22 @@ mod tests {
         {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         }

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -946,52 +946,70 @@ mod tests {
         #[cfg(unix)]
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink("missing", "test_data/links/link-missing") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink("abbbc/x", "test_data/links/link-notdir") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink("link-loop", "test_data/links/link-loop") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
         }
         #[cfg(windows)]
         {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
         }
 

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -111,12 +111,12 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         };
@@ -124,12 +124,12 @@ mod tests {
         let _ = {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         };

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -110,27 +110,35 @@ mod tests {
         #[cfg(unix)]
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
         };
         #[cfg(windows)]
         let _ = {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
-                if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {:?}", e);
-                }
+                assert!(
+                    !(e.kind() != ErrorKind::AlreadyExists),
+                    "Failed to create sym link: {:?}",
+                    e
+                );
             }
         };
 

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -111,12 +111,12 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         };
@@ -124,12 +124,12 @@ mod tests {
         let _ = {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                   assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {}", e);
                 }
             }
         };

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -111,14 +111,14 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
@@ -128,14 +128,14 @@ mod tests {
         let _ = {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 assert!(
-                    !(e.kind() != ErrorKind::AlreadyExists),
+                    e.kind() == ErrorKind::AlreadyExists,
                     "Failed to create sym link: {:?}",
                     e
                 );

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -111,12 +111,12 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         };
@@ -124,12 +124,12 @@ mod tests {
         let _ = {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    panic!("Failed to create sym link: {:?}", e);
+                   assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         };

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -111,12 +111,12 @@ mod tests {
         {
             if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         };
@@ -124,12 +124,12 @@ mod tests {
         let _ = {
             if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
             if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
                 if e.kind() != ErrorKind::AlreadyExists {
-                    assert!(false, "Failed to create sym link: {}", e);
+                    assert!(false, "Failed to create sym link: {:?}", e);
                 }
             }
         };

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -339,7 +339,7 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );
@@ -347,7 +347,7 @@ mod tests {
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -338,15 +338,19 @@ mod tests {
     fn create_file_link() {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
     }
 

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -339,13 +339,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -339,13 +339,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -339,13 +339,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -339,13 +339,13 @@ mod tests {
         #[cfg(unix)]
         if let Err(e) = symlink("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
         #[cfg(windows)]
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -322,22 +322,22 @@ fn find_printf() {
     {
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
         if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
         if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
         if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -322,28 +322,28 @@ fn find_printf() {
     {
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );
         }
         if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );
         }
         if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );
         }
         if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
             assert!(
-                !(e.kind() != ErrorKind::AlreadyExists),
+                e.kind() == ErrorKind::AlreadyExists,
                 "Failed to create sym link: {:?}",
                 e
             );

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -322,22 +322,22 @@ fn find_printf() {
     {
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
         if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
         if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
         if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
             if e.kind() != ErrorKind::AlreadyExists {
-               assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {}", e);
             }
         }
     }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -322,22 +322,22 @@ fn find_printf() {
     {
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
             if e.kind() != ErrorKind::AlreadyExists {
-                panic!("Failed to create sym link: {:?}", e);
+               assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -322,22 +322,22 @@ fn find_printf() {
     {
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
         if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
             if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {}", e);
+                assert!(false, "Failed to create sym link: {:?}", e);
             }
         }
     }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -321,24 +321,32 @@ fn find_printf() {
     #[cfg(windows)]
     {
         if let Err(e) = symlink_file("abbbc", "test_data/links/link-f") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
         if let Err(e) = symlink_dir("subdir", "test_data/links/link-d") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
         if let Err(e) = symlink_file("missing", "test_data/links/link-missing") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
         if let Err(e) = symlink_file("abbbc/x", "test_data/links/link-notdir") {
-            if e.kind() != ErrorKind::AlreadyExists {
-                assert!(false, "Failed to create sym link: {:?}", e);
-            }
+            assert!(
+                !(e.kind() != ErrorKind::AlreadyExists),
+                "Failed to create sym link: {:?}",
+                e
+            );
         }
     }
 


### PR DESCRIPTION
- Issue stated in [Issues #226](https://github.com/uutils/findutils/issues/226)
#226 

Used assert! statement instead of alert,  to indicate a failed condition without stopping the program immediately.

```
if e.kind() != ErrorKind::AlreadyExists {
    assert!(false, "Failed to create sym link: {:?}", e);
}
```