### PR TITLE
ci: update codecov-action to v4 & use token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,9 @@ jobs:
           path: lcov.info
 
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           # file: ${{ steps.grcov.outputs.report }}
           file: lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
This PR bumps `codecov-action` from `v3` to `v4` and uses the `codecov` token (which must be added to Github's settings).