### PR TITLE
find: fix "item x imported redundantly" warnings

### DIFF
--- a/src/find/matchers/access.rs
+++ b/src/find/matchers/access.rs
@@ -33,7 +33,6 @@ mod tests {
     use super::*;
 
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     #[test]

--- a/src/find/matchers/empty.rs
+++ b/src/find/matchers/empty.rs
@@ -61,7 +61,6 @@ mod tests {
 
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     #[test]

--- a/src/find/matchers/glob.rs
+++ b/src/find/matchers/glob.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use onig::{self, Regex, RegexOptions, Syntax};
+use onig::{Regex, RegexOptions, Syntax};
 
 /// Parse a string as a POSIX Basic Regular Expression.
 fn parse_bre(expr: &str, options: RegexOptions) -> Result<Regex, onig::Error> {

--- a/src/find/matchers/lname.rs
+++ b/src/find/matchers/lname.rs
@@ -60,7 +60,6 @@ impl Matcher for LinkNameMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     use std::io::ErrorKind;

--- a/src/find/matchers/logical_matchers.rs
+++ b/src/find/matchers/logical_matchers.rs
@@ -10,7 +10,6 @@
 //! when parsing command-line options (e.g. "-foo -o -bar -baz" is equivalent
 //! to "-foo -o ( -bar -baz )", not "( -foo -o -bar ) -baz").
 use std::error::Error;
-use std::iter::Iterator;
 use std::path::Path;
 use walkdir::DirEntry;
 
@@ -357,11 +356,9 @@ mod tests {
     use super::*;
     use crate::find::matchers::quit::QuitMatcher;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::{Matcher, MatcherIO};
     use crate::find::tests::FakeDependencies;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use walkdir::DirEntry;
 
     /// Simple Matcher impl that has side effects
     pub struct HasSideEffects;

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -544,8 +544,7 @@ mod tests {
     use super::*;
     use crate::find::tests::fix_up_slashes;
     use crate::find::tests::FakeDependencies;
-    use crate::find::Config;
-    use walkdir::{DirEntry, WalkDir};
+    use walkdir::WalkDir;
 
     /// Helper function for tests to get a DirEntry object. directory should
     /// probably be a string starting with "test_data/" (cargo's tests run with

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -33,7 +33,6 @@ impl Matcher for NameMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     use std::io::ErrorKind;

--- a/src/find/matchers/path.rs
+++ b/src/find/matchers/path.rs
@@ -33,7 +33,6 @@ impl Matcher for PathMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     // Variants of fix_up_slashes that properly escape the forward slashes for

--- a/src/find/matchers/perm.rs
+++ b/src/find/matchers/perm.rs
@@ -144,7 +144,6 @@ mod tests {
     use super::*;
 
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     #[track_caller]

--- a/src/find/matchers/printer.rs
+++ b/src/find/matchers/printer.rs
@@ -57,7 +57,6 @@ impl Matcher for Printer {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::fix_up_slashes;
     use crate::find::tests::FakeDependencies;
 

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -671,7 +671,6 @@ mod tests {
 
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::fix_up_slashes;
     use crate::find::tests::FakeDependencies;
 

--- a/src/find/matchers/prune.rs
+++ b/src/find/matchers/prune.rs
@@ -31,7 +31,6 @@ impl Matcher for PruneMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     #[test]

--- a/src/find/matchers/quit.rs
+++ b/src/find/matchers/quit.rs
@@ -22,7 +22,6 @@ impl Matcher for QuitMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     #[test]

--- a/src/find/matchers/regex.rs
+++ b/src/find/matchers/regex.rs
@@ -121,7 +121,6 @@ impl Matcher for RegexMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     const POSIX_BASIC_INTERVALS_RE: &str = r".*/ab\{1,3\}c";

--- a/src/find/matchers/size.rs
+++ b/src/find/matchers/size.rs
@@ -106,10 +106,7 @@ impl Matcher for SizeMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::{ComparableValue, Matcher};
     use crate::find::tests::FakeDependencies;
-    // need to explicitly use non-pub members
-    use super::{byte_size_to_unit_size, Unit};
 
     #[test]
     fn test_byte_size_to_unit_size() {

--- a/src/find/matchers/stat.rs
+++ b/src/find/matchers/stat.rs
@@ -84,7 +84,6 @@ mod tests {
     use super::*;
 
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
 
     #[test]

--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -139,15 +139,13 @@ impl FileTimeMatcher {
 #[cfg(test)]
 mod tests {
     use std::fs::{File, OpenOptions};
-    use std::io::{Read, Write};
+    use std::io::Read;
     use std::thread;
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
     use tempfile::Builder;
-    use walkdir::DirEntry;
 
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::{ComparableValue, Matcher};
     use crate::find::tests::FakeDependencies;
 
     #[test]

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -69,7 +69,6 @@ impl Matcher for TypeMatcher {
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;
-    use crate::find::matchers::Matcher;
     use crate::find::tests::FakeDependencies;
     use std::io::ErrorKind;
 

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -264,11 +264,9 @@ pub fn find_main<'a>(args: &[&str], deps: &'a dyn Dependencies<'a>) -> i32 {
 #[cfg(test)]
 mod tests {
 
-    use std::cell::RefCell;
     use std::fs;
-    use std::io::{Cursor, ErrorKind, Read, Write};
-    use std::time::{Duration, SystemTime};
-    use std::vec::Vec;
+    use std::io::{Cursor, ErrorKind, Read};
+    use std::time::Duration;
     use tempfile::Builder;
 
     #[cfg(unix)]

--- a/tests/common/test_helpers.rs
+++ b/tests/common/test_helpers.rs
@@ -8,7 +8,6 @@ use std::cell::RefCell;
 use std::env;
 use std::io::{Cursor, Read, Write};
 use std::time::SystemTime;
-use std::vec::Vec;
 use walkdir::{DirEntry, WalkDir};
 
 use findutils::find::matchers::MatcherIO;


### PR DESCRIPTION
This PR fixes many "item x imported redundantly" warnings I noticed in https://github.com/uutils/findutils/actions/runs/8043426350/job/21965483934?pr=324