### PR TITLE
find: fix two clippy warnings

### DIFF
--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -305,7 +305,7 @@ mod tests {
                 .write(true)
                 .open(&foo_path)
                 .expect("open temp file");
-            let _ = f.write(&mut buffer);
+            let _ = f.write(&buffer);
         }
 
         thread::sleep(Duration::from_secs(2));

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -160,7 +160,7 @@ mod tests {
         let deps = FakeDependencies::new();
 
         for typ in &["b", "c", "p", "s"] {
-            let matcher = TypeMatcher::new(typ.as_ref()).unwrap();
+            let matcher = TypeMatcher::new(typ).unwrap();
             assert!(!matcher.matches(&dir, &mut deps.new_matcher_io()));
             assert!(!matcher.matches(&file, &mut deps.new_matcher_io()));
         }


### PR DESCRIPTION
This PR fixes two clippy warnings from the [useless_asref](https://rust-lang.github.io/rust-clippy/master/index.html#/useless_asref) and [unnecessary_mut_passed](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_mut_passed) lints.