### PR TITLE
Cargo.toml: specify complete chrono version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Rust implementation of GNU findutils"
 authors = ["uutils developers"]
 
 [dependencies]
-chrono = "0.4"
+chrono = "0.4.35"
 clap = "4.5"
 faccess = "0.2.4"
 walkdir = "2.5"


### PR DESCRIPTION
This PR specifies the complete `chrono` version to get rid of the "maybe insecure" shown in the "dependencies" badge.