### PR TITLE
find: Fix unexpectedly accepted empty expression.

### DIFF
--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -505,3 +505,16 @@ fn find_accessible() {
         .stderr(predicate::str::is_empty())
         .stdout(predicate::str::contains("abbbc").not());
 }
+
+#[test]
+fn expression_empty_parentheses() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-true", "(", ")"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "empty parentheses are not allowed",
+        ))
+        .stdout(predicate::str::is_empty());
+}


### PR DESCRIPTION
fix: https://github.com/uutils/findutils/issues/29

This commit modifies a test function `build_top_level_matcher_too_many_brackets` outside of my code, 
which tests that `find -true \( \) \)` will return a `too many ')'` error.

But in GNU find, this instruction will first cause an `empty parentheses are not allowed` error, 
so it is changed to `find . -type f \( -name "*.txt" \) \)` to maintain compatibility.