### PR TITLE
clippy: Fix clippy warning.

### DIFF
--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -600,14 +600,14 @@ mod tests {
 
         // modified time test
         let modified_matcher = NewerTimeMatcher::new(NewerOptionType::Modified, time);
-        let mut buffer = [0; 10];
+        let buffer = [0; 10];
         {
             let mut file = OpenOptions::new()
                 .read(true)
                 .write(true)
                 .open(&foo_path)
                 .expect("open temp file");
-            let _ = file.write(&mut buffer);
+            let _ = file.write(&buffer);
         }
         assert!(
             modified_matcher.matches(&file_info, &mut deps.new_matcher_io()),

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -996,7 +996,7 @@ mod tests {
         use std::{path::Path, process::Command};
 
         let path = Path::new("./test_data/no_permission");
-        let _result = fs::create_dir(&path);
+        let _result = fs::create_dir(path);
         // Generate files without permissions.
         // std::fs cannot change file permissions to 000 in normal user state,
         // so use chmod via Command to change permissions.
@@ -1016,7 +1016,7 @@ mod tests {
         uucore::error::set_exit_code(0);
 
         if path.exists() {
-            let _result = fs::create_dir(&path);
+            let _result = fs::create_dir(path);
             // Remove the unreadable and writable status of the file to avoid affecting other tests.
             let _output = Command::new("chmod")
                 .arg("+rwx")


### PR DESCRIPTION
I'm sorry that I wrote some redundant code at https://github.com/uutils/findutils/pull/353 and https://github.com/uutils/findutils/pull/342 which caused `cargo clippy --all-targets --all-features` to generate multiple warnings.

Fix them in this PR.