### PR TITLE
find: Fix `convert_arg_to_comparable_value()` function parsing unexpected characters.

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -220,7 +220,7 @@ fn convert_arg_to_comparable_value(
     option_name: &str,
     value_as_string: &str,
 ) -> Result<ComparableValue, Box<dyn Error>> {
-    let re = Regex::new(r"([+-]?)(\d+)$")?;
+    let re = Regex::new(r"^([+-]?)(\d+)$")?;
     if let Some(groups) = re.captures(value_as_string) {
         if let Ok(val) = groups[2].parse::<u64>() {
             return Ok(match &groups[1] {
@@ -1257,6 +1257,20 @@ mod tests {
             assert!(e.to_string().contains("missing argument"));
         } else {
             panic!("-perm with no mode pattern should fail");
+        }
+    }
+
+    #[test]
+    fn convert_exception_arg_to_comparable_value_test() {
+        let exception_args = ["1%2", "1%2%3", "1a2", "1%2a", "abc", "-", "+", "%"];
+
+        for arg in exception_args {
+            let comparable = convert_arg_to_comparable_value("test", arg);
+            assert!(
+                comparable.is_err(),
+                "{} should be parse to Comparable correctly",
+                arg
+            );
         }
     }
 

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -507,6 +507,32 @@ fn find_accessible() {
 }
 
 #[test]
+fn find_time() {
+    let args = ["1", "+1", "-1"];
+    let exception_args = ["1%2", "1%2%3", "1a2", "1%2a", "abc", "-", "+", "%"];
+
+    ["-ctime", "-atime", "-mtime"].iter().for_each(|flag| {
+        args.iter().for_each(|arg| {
+            Command::cargo_bin("find")
+                .expect("found binary")
+                .args([".", flag, arg])
+                .assert()
+                .success()
+                .stderr(predicate::str::is_empty());
+        });
+
+        exception_args.iter().for_each(|arg| {
+            Command::cargo_bin("find")
+                .expect("found binary")
+                .args([".", flag, arg])
+                .assert()
+                .failure()
+                .stdout(predicate::str::is_empty());
+        });
+    });
+}
+
+#[test]
 fn expression_empty_parentheses() {
     Command::cargo_bin("find")
         .expect("found binary")


### PR DESCRIPTION
convert_arg_to_comparable_value() as mentioned in https://github.com/uutils/findutils/pull/355#issuecomment-2067613423 parses some strange characters. 

The original regular expression was `([+-]?)(\d+)$` , which did a partial match and only included `1%2` of `2` as part of the match. 
After adding the `^` limiter (`^([+-]?)(\d+)$`), the expression can be restricted to only match `+` `-` or `0-9`.