### PR TITLE
find: replace `zip` with nested loops in tests

### DIFF
--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -921,15 +921,17 @@ mod tests {
         let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
         let times = ["jan 01, 2000", "jan 01, 2000 00:00:00"];
 
-        for (arg, time) in args.iter().zip(times.iter()) {
-            let deps = FakeDependencies::new();
-            let rc = find_main(&["find", "./test_data/simple/subdir", arg, time], &deps);
+        for arg in args {
+            for time in times {
+                let deps = FakeDependencies::new();
+                let rc = find_main(&["find", "./test_data/simple/subdir", arg, time], &deps);
 
-            assert_eq!(rc, 0);
-            assert_eq!(
-                deps.get_output_as_string(),
-                fix_up_slashes("./test_data/simple/subdir\n./test_data/simple/subdir/ABBBC\n"),
-            );
+                assert_eq!(rc, 0);
+                assert_eq!(
+                    deps.get_output_as_string(),
+                    fix_up_slashes("./test_data/simple/subdir\n./test_data/simple/subdir/ABBBC\n"),
+                );
+            }
         }
     }
 
@@ -942,12 +944,14 @@ mod tests {
         let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
         let times = ["jan 01, 2037", "jan 01, 2037 00:00:00"];
 
-        for (arg, time) in args.iter().zip(times.iter()) {
-            let deps = FakeDependencies::new();
-            let rc = find_main(&["find", "./test_data/simple/subdir", arg, time], &deps);
+        for arg in args {
+            for time in times {
+                let deps = FakeDependencies::new();
+                let rc = find_main(&["find", "./test_data/simple/subdir", arg, time], &deps);
 
-            assert_eq!(rc, 0);
-            assert_eq!(deps.get_output_as_string(), "");
+                assert_eq!(rc, 0);
+                assert_eq!(deps.get_output_as_string(), "");
+            }
         }
     }
 


### PR DESCRIPTION
This PR replaces the use of `zip` with nested loops because it was mistakenly assumed that `zip` creates the Cartesian product of two lists.