### PR TITLE
find: Implement `-anewer` and `-cnewer`.

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -1306,6 +1306,10 @@ mod tests {
 
     #[test]
     fn parse_str_to_newer_args_test() {
+        // test for error case
+        let arg = parse_str_to_newer_args("");
+        assert!(arg.is_none());
+
         // test for short options
         // -newer equivalent to -newermm
         let arg = parse_str_to_newer_args("-newer").unwrap();

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -296,7 +296,29 @@ fn parse_date_str_to_timestamps(date_str: &str) -> Option<i64> {
 /// X and Y from the -newerXY string.
 /// X and Y are constrained to a/B/c/m and t.
 /// such as: "-neweraB" -> Some(a, B) "-neweraD" -> None
+///
+/// Additionally, there is support for the -anewer and -cnewer short arguments. as follows:
+/// 1. -anewer is equivalent to -neweram
+/// 2. -cnewer is equivalent to - newercm
+///
+/// If -newer is used it will be resolved to -newermm.
 fn parse_str_to_newer_args(input: &str) -> Option<(String, String)> {
+    if input.is_empty() {
+        return None;
+    }
+
+    if input == "-newer" {
+        return Some(("m".to_string(), "m".to_string()));
+    }
+
+    if input == "-anewer" {
+        return Some(("a".to_string(), "m".to_string()));
+    }
+
+    if input == "-cnewer" {
+        return Some(("c".to_string(), "m".to_string()));
+    }
+
     let re = Regex::new(r"-newer([aBcm])([aBcmt])").unwrap();
     if let Some(captures) = re.captures(input) {
         let x = captures.get(1)?.as_str().to_string();
@@ -1284,6 +1306,19 @@ mod tests {
 
     #[test]
     fn parse_str_to_newer_args_test() {
+        // test for short options
+        // -newer equivalent to -newermm
+        let arg = parse_str_to_newer_args("-newer").unwrap();
+        assert_eq!(("m".to_string(), "m".to_string()), arg);
+
+        // -anewer equivalent to -neweram
+        let arg = parse_str_to_newer_args("-anewer").unwrap();
+        assert_eq!(("a".to_string(), "m".to_string()), arg);
+
+        // -cnewer equivalent to - newercm
+        let arg = parse_str_to_newer_args("-cnewer").unwrap();
+        assert_eq!(("c".to_string(), "m".to_string()), arg);
+
         let x_options = ["a", "B", "c", "m"];
         let y_options = ["a", "B", "c", "m", "t"];
 

--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -510,8 +510,8 @@ mod tests {
         #[cfg(not(target_os = "linux"))]
         let options = ["a", "B", "c", "m"];
 
-        for x_option in &options {
-            for y_option in &options {
+        for x_option in options {
+            for y_option in options {
                 let temp_dir = Builder::new().prefix("example").tempdir().unwrap();
                 let temp_dir_path = temp_dir.path().to_string_lossy();
                 let new_file_name = "newFile";

--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -506,16 +506,12 @@ mod tests {
     #[test]
     fn newer_option_matcher() {
         #[cfg(target_os = "linux")]
-        let x_options = ["a", "c", "m"];
+        let options = ["a", "c", "m"];
         #[cfg(not(target_os = "linux"))]
-        let x_options = ["a", "B", "c", "m"];
-        #[cfg(target_os = "linux")]
-        let y_options = ["a", "c", "m"];
-        #[cfg(not(target_os = "linux"))]
-        let y_options = ["a", "B", "c", "m"];
+        let options = ["a", "B", "c", "m"];
 
-        for x_option in &x_options {
-            for y_option in &y_options {
+        for x_option in &options {
+            for y_option in &options {
                 let temp_dir = Builder::new().prefix("example").tempdir().unwrap();
                 let temp_dir_path = temp_dir.path().to_string_lossy();
                 let new_file_name = "newFile";

--- a/src/find/matchers/time.rs
+++ b/src/find/matchers/time.rs
@@ -522,8 +522,8 @@ mod tests {
                 let old_file = get_dir_entry_for("test_data", "simple");
                 let deps = FakeDependencies::new();
                 let matcher = NewerOptionMatcher::new(
-                    (*x_option).to_string(),
-                    (*y_option).to_string(),
+                    x_option.to_string(),
+                    y_option.to_string(),
                     &old_file.path().to_string_lossy(),
                 );
 
@@ -538,8 +538,8 @@ mod tests {
                 // thus causing the Matcher to generate an IO error after matching.
                 let _ = fs::remove_file(&*new_file.path().to_string_lossy());
                 let matcher = NewerOptionMatcher::new(
-                    (*x_option).to_string(),
-                    (*y_option).to_string(),
+                    x_option.to_string(),
+                    y_option.to_string(),
                     &old_file.path().to_string_lossy(),
                 );
                 assert!(

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -916,13 +916,9 @@ mod tests {
     fn test_find_newer_xy_before_created_time() {
         // normal - before the created time
         #[cfg(target_os = "linux")]
-        let args = [
-            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerct", "-newermt"];
         #[cfg(not(target_os = "linux"))]
-        let args = [
-            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
         let times = ["jan 01, 2000", "jan 01, 2000 00:00:00"];
 
         for (arg, time) in args.iter().zip(times.iter()) {
@@ -941,13 +937,9 @@ mod tests {
     fn test_find_newer_xy_after_created_time() {
         // normal - after the created time
         #[cfg(target_os = "linux")]
-        let args = [
-            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerct", "-newermt"];
         #[cfg(not(target_os = "linux"))]
-        let args = [
-            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
         let times = ["jan 01, 2037", "jan 01, 2037 00:00:00"];
 
         for (arg, time) in args.iter().zip(times.iter()) {
@@ -966,13 +958,9 @@ mod tests {
         // Therefore, the files checkout of the git repository while
         // this test was running are likely to be newer than the default time.
         #[cfg(target_os = "linux")]
-        let args = [
-            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerct", "-newermt"];
         #[cfg(not(target_os = "linux"))]
-        let args = [
-            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
         let time = "";
 
         for &arg in &args {
@@ -989,13 +977,9 @@ mod tests {
     fn test_find_newer_xy_error_time() {
         // Catch a parsing error.
         #[cfg(target_os = "linux")]
-        let args = [
-            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerct", "-newermt"];
         #[cfg(not(target_os = "linux"))]
-        let args = [
-            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
-        ];
+        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
         let time = "2037, jan 01";
 
         for &arg in &args {

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -916,9 +916,13 @@ mod tests {
     fn test_find_newer_xy_before_created_time() {
         // normal - before the created time
         #[cfg(target_os = "linux")]
-        let args = ["-newerat", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         #[cfg(not(target_os = "linux"))]
-        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         let times = ["jan 01, 2000", "jan 01, 2000 00:00:00"];
 
         for (arg, time) in args.iter().zip(times.iter()) {
@@ -937,9 +941,13 @@ mod tests {
     fn test_find_newer_xy_after_created_time() {
         // normal - after the created time
         #[cfg(target_os = "linux")]
-        let args = ["-newerat", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         #[cfg(not(target_os = "linux"))]
-        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         let times = ["jan 01, 2037", "jan 01, 2037 00:00:00"];
 
         for (arg, time) in args.iter().zip(times.iter()) {
@@ -958,9 +966,13 @@ mod tests {
         // Therefore, the files checkout of the git repository while
         // this test was running are likely to be newer than the default time.
         #[cfg(target_os = "linux")]
-        let args = ["-newerat", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         #[cfg(not(target_os = "linux"))]
-        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         let time = "";
 
         for &arg in &args {
@@ -977,9 +989,13 @@ mod tests {
     fn test_find_newer_xy_error_time() {
         // Catch a parsing error.
         #[cfg(target_os = "linux")]
-        let args = ["-newerat", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         #[cfg(not(target_os = "linux"))]
-        let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
+        let args = [
+            "-newerat", "-newerBt", "-newerct", "-newermt", "-newer", "-anewer", "-cnewer",
+        ];
         let time = "2037, jan 01";
 
         for &arg in &args {

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -518,3 +518,50 @@ fn expression_empty_parentheses() {
         ))
         .stdout(predicate::str::is_empty());
 }
+
+#[test]
+#[serial(working_dir)]
+fn find_newer_xy() {
+    #[cfg(target_os = "linux")]
+    let x_options = ["a", "c", "m"];
+    #[cfg(not(target_os = "linux"))]
+    let x_options = ["a", "B", "c", "m"];
+    #[cfg(target_os = "linux")]
+    let y_options = ["a", "c", "m"];
+    #[cfg(not(target_os = "linux"))]
+    let y_options = ["a", "B", "c", "m"];
+
+    for &x in &x_options {
+        for &y in &y_options {
+            let arg = &format!("-newer{x}{y}").to_string();
+            Command::cargo_bin("find")
+                .expect("found binary")
+                .args([
+                    "./test_data/simple/subdir",
+                    arg,
+                    "./test_data/simple/subdir/ABBBC",
+                ])
+                .assert()
+                .success()
+                .stderr(predicate::str::is_empty());
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    let args = ["-newerat", "-newerct", "-newermt"];
+    #[cfg(not(target_os = "linux"))]
+    let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
+    let times = ["jan 01, 2000", "jan 01, 2000 00:00:00"];
+
+    for &arg in &args {
+        for &time in &times {
+            let arg = &format!("{arg}{time}").to_string();
+            Command::cargo_bin("find")
+                .expect("found binary")
+                .args(["./test_data/simple/subdir", arg, time])
+                .assert()
+                .success()
+                .stderr(predicate::str::is_empty());
+        }
+    }
+}

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -527,9 +527,9 @@ fn find_newer_xy() {
     #[cfg(not(target_os = "linux"))]
     let options = ["a", "B", "c", "m"];
 
-    for &x in &options {
-        for &y in &options {
-            let arg = &format!("-newer{x}{y}").to_string();
+    for x in options {
+        for y in options {
+            let arg = &format!("-newer{x}{y}");
             Command::cargo_bin("find")
                 .expect("found binary")
                 .args([
@@ -549,9 +549,9 @@ fn find_newer_xy() {
     let args = ["-newerat", "-newerBt", "-newerct", "-newermt"];
     let times = ["jan 01, 2000", "jan 01, 2000 00:00:00"];
 
-    for &arg in &args {
-        for &time in &times {
-            let arg = &format!("{arg}{time}").to_string();
+    for arg in args {
+        for time in times {
+            let arg = &format!("{arg}{time}");
             Command::cargo_bin("find")
                 .expect("found binary")
                 .args(["./test_data/simple/subdir", arg, time])

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -523,16 +523,12 @@ fn expression_empty_parentheses() {
 #[serial(working_dir)]
 fn find_newer_xy() {
     #[cfg(target_os = "linux")]
-    let x_options = ["a", "c", "m"];
+    let options = ["a", "c", "m"];
     #[cfg(not(target_os = "linux"))]
-    let x_options = ["a", "B", "c", "m"];
-    #[cfg(target_os = "linux")]
-    let y_options = ["a", "c", "m"];
-    #[cfg(not(target_os = "linux"))]
-    let y_options = ["a", "B", "c", "m"];
+    let options = ["a", "B", "c", "m"];
 
-    for &x in &x_options {
-        for &y in &y_options {
+    for &x in &options {
+        for &y in &options {
             let arg = &format!("-newer{x}{y}").to_string();
             Command::cargo_bin("find")
                 .expect("found binary")


### PR DESCRIPTION
implement: https://github.com/uutils/findutils/issues/370

Added extra judgment to `parse_str_to_newer_args()` function.
1. `-anewer` is equivalent to `-neweram`
2. `-cnewer` is equivalent to `-newercm`
3. `-newer` is equicalent to `-newermm`


BFS test `+1 PASS` in commit 57f2a3bc0751f617933f551a531bdf45acdf77fd.

This PR **does not** solve [Parsing multiple time formats](https://github.com/uutils/findutils/issues/384), I will open a new PR to handle it separately. : )