### PR TITLE
ci: run `cargo test` instead of `cargo check` in "cargo test" jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
       - run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-latest'
 
-      - name: Check
+      - name: Test
         run: |
-          cargo check
+          cargo test
 
   fmt:
     name: cargo fmt --all -- --check


### PR DESCRIPTION
I noticed that while we have jobs named "cargo test" in the CI, they don't run `cargo test` but `cargo check`, and are almost identical to the "cargo check" jobs. This PR runs `cargo test` instead of `cargo check` in the "cargo test" jobs.