### PR TITLE
find: make `InodeMatcher` & `LinksMatcher` unix-only

### DIFF
--- a/src/find/matchers/stat.rs
+++ b/src/find/matchers/stat.rs
@@ -4,10 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
-use std::error::Error;
 use walkdir::DirEntry;
 
 use super::{ComparableValue, Matcher, MatcherIO};
@@ -18,31 +16,17 @@ pub struct InodeMatcher {
 }
 
 impl InodeMatcher {
-    #[cfg(unix)]
-    pub fn new(ino: ComparableValue) -> Result<Self, Box<dyn Error>> {
-        Ok(Self { ino })
-    }
-
-    #[cfg(not(unix))]
-    pub fn new(_ino: ComparableValue) -> Result<Self, Box<dyn Error>> {
-        Err(From::from(
-            "Inode numbers are not available on this platform",
-        ))
+    pub fn new(ino: ComparableValue) -> Self {
+        Self { ino }
     }
 }
 
 impl Matcher for InodeMatcher {
-    #[cfg(unix)]
     fn matches(&self, file_info: &DirEntry, _: &mut MatcherIO) -> bool {
         match file_info.metadata() {
             Ok(metadata) => self.ino.matches(metadata.ino()),
             Err(_) => false,
         }
-    }
-
-    #[cfg(not(unix))]
-    fn matches(&self, _: &DirEntry, _: &mut MatcherIO) -> bool {
-        unreachable!("Inode numbers are not available on this platform")
     }
 }
 
@@ -52,29 +36,17 @@ pub struct LinksMatcher {
 }
 
 impl LinksMatcher {
-    #[cfg(unix)]
-    pub fn new(nlink: ComparableValue) -> Result<Self, Box<dyn Error>> {
-        Ok(Self { nlink })
-    }
-
-    #[cfg(not(unix))]
-    pub fn new(_nlink: ComparableValue) -> Result<Self, Box<dyn Error>> {
-        Err(From::from("Link counts are not available on this platform"))
+    pub fn new(nlink: ComparableValue) -> Self {
+        Self { nlink }
     }
 }
 
 impl Matcher for LinksMatcher {
-    #[cfg(unix)]
     fn matches(&self, file_info: &DirEntry, _: &mut MatcherIO) -> bool {
         match file_info.metadata() {
             Ok(metadata) => self.nlink.matches(metadata.nlink()),
             Err(_) => false,
         }
-    }
-
-    #[cfg(not(unix))]
-    fn matches(&self, _: &DirEntry, _: &mut MatcherIO) -> bool {
-        unreachable!("Link counts are not available on this platform")
     }
 }
 
@@ -92,19 +64,19 @@ mod tests {
         let metadata = file_info.metadata().unwrap();
         let deps = FakeDependencies::new();
 
-        let matcher = InodeMatcher::new(ComparableValue::EqualTo(metadata.ino())).unwrap();
+        let matcher = InodeMatcher::new(ComparableValue::EqualTo(metadata.ino()));
         assert!(
             matcher.matches(&file_info, &mut deps.new_matcher_io()),
             "inode number should match"
         );
 
-        let matcher = InodeMatcher::new(ComparableValue::LessThan(metadata.ino())).unwrap();
+        let matcher = InodeMatcher::new(ComparableValue::LessThan(metadata.ino()));
         assert!(
             !matcher.matches(&file_info, &mut deps.new_matcher_io()),
             "inode number should not match"
         );
 
-        let matcher = InodeMatcher::new(ComparableValue::MoreThan(metadata.ino())).unwrap();
+        let matcher = InodeMatcher::new(ComparableValue::MoreThan(metadata.ino()));
         assert!(
             !matcher.matches(&file_info, &mut deps.new_matcher_io()),
             "inode number should not match"
@@ -116,19 +88,19 @@ mod tests {
         let file_info = get_dir_entry_for("test_data/simple", "abbbc");
         let deps = FakeDependencies::new();
 
-        let matcher = LinksMatcher::new(ComparableValue::EqualTo(1)).unwrap();
+        let matcher = LinksMatcher::new(ComparableValue::EqualTo(1));
         assert!(
             matcher.matches(&file_info, &mut deps.new_matcher_io()),
             "link count should match"
         );
 
-        let matcher = LinksMatcher::new(ComparableValue::LessThan(1)).unwrap();
+        let matcher = LinksMatcher::new(ComparableValue::LessThan(1));
         assert!(
             !matcher.matches(&file_info, &mut deps.new_matcher_io()),
             "link count should not match"
         );
 
-        let matcher = LinksMatcher::new(ComparableValue::MoreThan(1)).unwrap();
+        let matcher = LinksMatcher::new(ComparableValue::MoreThan(1));
         assert!(
             !matcher.matches(&file_info, &mut deps.new_matcher_io()),
             "link count should not match"

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -441,6 +441,18 @@ fn find_inum() {
         .stdout(predicate::str::contains("abbbc"));
 }
 
+#[cfg(not(unix))]
+#[test]
+fn find_inum() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["test_data", "-inum", "1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not available on this platform"))
+        .stdout(predicate::str::is_empty());
+}
+
 #[cfg(unix)]
 #[serial(working_dir)]
 #[test]
@@ -452,6 +464,18 @@ fn find_links() {
         .success()
         .stderr(predicate::str::is_empty())
         .stdout(predicate::str::contains("abbbc"));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn find_links() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["test_data", "-links", "1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not available on this platform"))
+        .stdout(predicate::str::is_empty());
 }
 
 #[serial(working_dir)]


### PR DESCRIPTION
This PR is a refactoring that makes the implementations of `InodeMatcher` and `LinksMatcher` unix-only. And moves the error handling for other platforms to where we handle `-inum` and `-links`.

The refactoring is done to get rid of two "field x is never read" warnings on Windows (see, for example, https://github.com/uutils/findutils/actions/runs/9271426702/job/25506758917#step:6:185)