### PR TITLE
find: remove unused import on Windows

### DIFF
--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -277,7 +277,7 @@ mod tests {
     use std::os::unix::fs::symlink;
 
     #[cfg(windows)]
-    use std::os::windows::fs::{symlink_dir, symlink_file};
+    use std::os::windows::fs::symlink_file;
 
     use crate::find::matchers::MatcherIO;
 


### PR DESCRIPTION
This PR removes an unused import on Windows to fix the corresponding warning (see, for example, https://github.com/uutils/findutils/actions/runs/9285549600/job/25550305051#step:6:232).