### PR TITLE
xargs: use `#[allow(dead_code)]` for enum

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -306,6 +306,7 @@ impl CommandResult {
     }
 }
 
+#[allow(dead_code)] // `Killed` variant is never constructed on Windows
 #[derive(Debug)]
 enum CommandExecutionError {
     // exit code 255


### PR DESCRIPTION
This PR adds `#[allow(dead_code)]` to the `CommandExecutionError` enum to avoid a "variant `Killed` is never constructed" warning on Windows (see, for example, https://github.com/uutils/findutils/actions/runs/9298475960/job/25590452513?pr=395#step:6:201).