### PR TITLE
Implement `-ignore_readdir_race` and `-noignore_readdir_race`.

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -692,6 +692,14 @@ fn build_matcher_tree(
 
                 return Ok((i, top_level_matcher.build()));
             }
+            "-ignore_readdir_race" => {
+                config.ignore_readdir_race = true;
+                None
+            }
+            "-noignore_readdir_race" => {
+                config.ignore_readdir_race = false;
+                None
+            }
             "-d" | "-depth" => {
                 // TODO add warning if it appears after actual testing criterion
                 config.depth_first = true;

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -708,6 +708,7 @@ fn build_matcher_tree(
             "-noignore_readdir_race" => {
                 config.ignore_readdir_race = false;
                 None
+            }
             "-daystart" => {
                 config.today_start = true;
                 None

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -692,11 +692,11 @@ fn build_matcher_tree(
 
                 return Ok((i, top_level_matcher.build()));
             }
-            // In our implementation, including the `-exec` parameter, 
-            // it is always run in a single thread. 
+            // In our implementation, including the `-exec` parameter,
+            // it is always run in a single thread.
             // Therefore, there is no race condition for now.
             // and we currently only add the corresponding fields in Config.
-            // 
+            //
             // Related: https://github.com/uutils/findutils/pull/411#issuecomment-2210638686
             "-ignore_readdir_race" => {
                 config.ignore_readdir_race = true;

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -692,6 +692,12 @@ fn build_matcher_tree(
 
                 return Ok((i, top_level_matcher.build()));
             }
+            // In our implementation, including the `-exec` parameter, 
+            // it is always run in a single thread. 
+            // Therefore, there is no race condition for now.
+            // and we currently only add the corresponding fields in Config.
+            // 
+            // Related: https://github.com/uutils/findutils/pull/411#issuecomment-2210638686
             "-ignore_readdir_race" => {
                 config.ignore_readdir_race = true;
                 None

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -34,6 +34,7 @@ impl Default for Config {
             sorted_output: false,
             help_requested: false,
             version_requested: false,
+            // For compat: doesn't change anything
             ignore_readdir_race: false,
         }
     }

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -1221,4 +1221,35 @@ mod tests {
 
         assert_eq!(rc, 0);
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_ignore_readdir_race() {
+        use crate::find::tests::FakeDependencies;
+
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &["find", "./test_data/simple/subdir", "-ignore_readdir_race"],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn test_noignore_readdir_race() {
+        use crate::find::tests::FakeDependencies;
+
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                "./test_data/simple/subdir",
+                "-noignore_readdir_race",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+    }
 }

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -21,6 +21,7 @@ pub struct Config {
     sorted_output: bool,
     help_requested: bool,
     version_requested: bool,
+    ignore_readdir_race: bool,
 }
 
 impl Default for Config {
@@ -33,6 +34,7 @@ impl Default for Config {
             sorted_output: false,
             help_requested: false,
             version_requested: false,
+            ignore_readdir_race: false,
         }
     }
 }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -881,3 +881,27 @@ fn find_samefile() {
         .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains("not-exist-file"));
 }
+
+#[test]
+#[serial(working_dir)]
+fn find_ignore_readdir_race() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["./test_data/simple/subdir", "-ignore_readdir_race"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("./test_data/simple/subdir"))
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+#[serial(working_dir)]
+fn find_noignore_readdir_race() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["./test_data/simple/subdir", "-noignore_readdir_race"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("./test_data/simple/subdir"))
+        .stderr(predicate::str::is_empty());
+}


### PR DESCRIPTION
This PR will pass the test about race conditions in BFS test. Our implementation does not seem to cause race conditions, so only add `Config` related to `-ignore_readdir_race` and `-noignore_readdir_race` without making other logical changes.

Closes #377