### PR TITLE
Implement `-noleaf`

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -692,6 +692,10 @@ fn build_matcher_tree(
 
                 return Ok((i, top_level_matcher.build()));
             }
+            "-noleaf" => {
+                config.no_leaf_dirs = true;
+                None
+            }
             "-d" | "-depth" => {
                 // TODO add warning if it appears after actual testing criterion
                 config.depth_first = true;

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -158,9 +158,9 @@ fn process_dir<'a>(
             }
             Ok(entry) => {
                 let mut matcher_io = matchers::MatcherIO::new(deps);
-                // Subdirectory search optimization, 
-                // skipping directories if the directory entry has 
-                // only two hard links (. and .. on Linux file systems) or 
+                // Subdirectory search optimization,
+                // skipping directories if the directory entry has
+                // only two hard links (. and .. on Linux file systems) or
                 // less than two hard links (on Windows systems).
                 if config.no_leaf_dirs && entry.file_type().is_dir() {
                     #[cfg(unix)]

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -881,3 +881,15 @@ fn find_samefile() {
         .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains("not-exist-file"));
 }
+
+#[test]
+#[serial(working_dir)]
+fn find_noleaf() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["test_data/simple/subdir", "-noleaf"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("test_data/simple/subdir"))
+        .stderr(predicate::str::is_empty());
+}


### PR DESCRIPTION
We use the walkdir library for directory traversal in our codebase, and the current predicates are all secondary filtering on the results returned by walkdir. So I guess `-noleaf` will not bring any optimization (unless `walkdir` includes this optimization, to be honest I don't know much about `walkdir` and didn't find any related functions in their documentation).

The current code only contains compatibility code.

Closes #376