### PR TITLE
Implement simple caching for -fstype

### DIFF
--- a/src/find/matchers/fs.rs
+++ b/src/find/matchers/fs.rs
@@ -37,7 +37,9 @@ pub fn get_file_system_type(
 ) -> Result<String, Box<dyn Error>> {
     use std::os::unix::fs::MetadataExt;
 
-    let metadata = match path.metadata() {
+    // use symlink_metadata (lstat under the hood) instead of metadata (stat) to make sure that it
+    // does not return an error when there is a (broken) symlink; this is aligned with GNU find.
+    let metadata = match path.symlink_metadata() {
         Ok(metadata) => metadata,
         Err(err) => Err(err)?,
     };

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -1206,10 +1206,12 @@ mod tests {
     fn test_fs_matcher() {
         use crate::find::tests::FakeDependencies;
         use matchers::fs::get_file_system_type;
+        use std::cell::RefCell;
         use std::path::Path;
 
         let path = Path::new("./test_data/simple/subdir");
-        let target_fs_type = get_file_system_type(path).unwrap();
+        let empty_cache = RefCell::new(None);
+        let target_fs_type = get_file_system_type(path, &empty_cache).unwrap();
 
         // should match fs type
         let deps = FakeDependencies::new();

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -830,6 +830,19 @@ fn find_fs() {
         .success()
         .stdout(predicate::str::is_empty())
         .stderr(predicate::str::is_empty());
+
+    let path = Path::new("./test_data/links");
+    let empty_cache = RefCell::new(None);
+    let target_fs_type = get_file_system_type(path, &empty_cache).unwrap();
+
+    // working with broken links
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["./test_data/links", "-fstype", &target_fs_type])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("./test_data/links/link-missing"))
+        .stderr(predicate::str::is_empty());
 }
 
 #[test]

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -785,10 +785,12 @@ fn find_age_range() {
 #[serial(working_dir)]
 fn find_fs() {
     use findutils::find::matchers::fs::get_file_system_type;
+    use std::cell::RefCell;
     use std::path::Path;
 
     let path = Path::new("./test_data/simple/subdir");
-    let target_fs_type = get_file_system_type(path).unwrap();
+    let empty_cache = RefCell::new(None);
+    let target_fs_type = get_file_system_type(path, &empty_cache).unwrap();
 
     // match fs type
     Command::cargo_bin("find")


### PR DESCRIPTION
Fix #418.

Before:

```
Benchmark 1: find ~/Workspace -fstype xfs
  Time (mean ± σ):     195.8 ms ±   3.2 ms    [User: 34.7 ms, System: 160.7 ms]
  Range (min … max):   192.4 ms … 202.4 ms    14 runs

Benchmark 2: target/release/find ~/Workspace -fstype xfs
  Time (mean ± σ):     12.494 s ±  0.098 s    [User: 2.645 s, System: 8.936 s]
  Range (min … max):   12.318 s … 12.670 s    10 runs

Summary
  find ~/Workspace -fstype xfs ran
   63.80 ± 1.16 times faster than target/release/find ~/Workspace -fstype xfs
```

After:

```
Benchmark 1: find ~/Workspace -fstype xfs
  Time (mean ± σ):     190.7 ms ±   3.4 ms    [User: 30.6 ms, System: 159.8 ms]
  Range (min … max):   186.9 ms … 198.0 ms    15 runs

Benchmark 2: target/release/find ~/Workspace -fstype xfs
  Time (mean ± σ):     284.1 ms ±   3.2 ms    [User: 67.8 ms, System: 215.7 ms]
  Range (min … max):   278.7 ms … 289.0 ms    10 runs

Summary
  find ~/Workspace -fstype xfs ran
    1.49 ± 0.03 times faster than target/release/find ~/Workspace -fstype xfs
```

Not exactly as fast, but significantly faster than no caching.