### PR TITLE
find: fix needless borrow clippy warning

### DIFF
--- a/src/find/matchers/exec.rs
+++ b/src/find/matchers/exec.rs
@@ -67,7 +67,7 @@ impl Matcher for SingleExecMatcher {
         for arg in &self.args {
             match *arg {
                 Arg::LiteralArg(ref a) => command.arg(a.as_os_str()),
-                Arg::FileArg(ref parts) => command.arg(&parts.join(path_to_file.as_os_str())),
+                Arg::FileArg(ref parts) => command.arg(parts.join(path_to_file.as_os_str())),
             };
         }
         if self.exec_in_parent_dir {


### PR DESCRIPTION
This PR fixes a warning from the [needless_borrows_for_generic_args](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrows_for_generic_args) lint.