### PR TITLE
find: use array instead of closure

### DIFF
--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -305,7 +305,7 @@ impl FormatStringParser<'_> {
     pub fn parse(&mut self) -> Result<FormatString, Box<dyn Error>> {
         let mut components = vec![];
 
-        while let Some(i) = self.string.find(|c| c == '%' || c == '\\') {
+        while let Some(i) = self.string.find(['%', '\\']) {
             if i > 0 {
                 // safe to unwrap: i is an index into the string, so it cannot
                 // be any shorter.


### PR DESCRIPTION
This PR fixes a warning from the [manual_pattern_char_comparison](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_pattern_char_comparison) lint introduced with Rust 1.81.