### PR TITLE
find: fix new clippy warnings

### DIFF
--- a/src/find/matchers/logical_matchers.rs
+++ b/src/find/matchers/logical_matchers.rs
@@ -356,7 +356,6 @@ impl Matcher for NotMatcher {
 }
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use crate::find::matchers::quit::QuitMatcher;

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -143,7 +143,7 @@ pub struct MatcherIO<'a> {
     deps: &'a dyn Dependencies,
 }
 
-impl<'a> MatcherIO<'a> {
+impl MatcherIO<'_> {
     pub fn new(deps: &dyn Dependencies) -> MatcherIO<'_> {
         MatcherIO {
             should_skip_dir: false,

--- a/src/find/matchers/prune.rs
+++ b/src/find/matchers/prune.rs
@@ -24,8 +24,8 @@ impl Matcher for PruneMatcher {
         true
     }
 }
-#[cfg(test)]
 
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;


### PR DESCRIPTION
This PR fixes some new clippy warnings from the [needless_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes) and [empty_line_after_outer_attr](https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_outer_attr) lints.