### PR TITLE
ci: Fix issues related to downloading builds in ci.

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           # Enable sources & install dependencies
-          sudo find /etc/apt/sources.list* -type f -exec sed -i 'p; s/^deb /deb-src /' '{}' +
+          sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
           sudo apt-get update
           sudo apt-get build-dep bfs
       - name: Run BFS tests

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -52,7 +52,7 @@ jobs:
           name: gnu-result
           path: gnu-result.json
       - name: Download the result
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v7
         with:
           workflow: compat.yml
           workflow_conclusion: completed
@@ -61,7 +61,7 @@ jobs:
           branch: main
           path: dl
       - name: Download the log
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v7
         with:
           workflow: compat.yml
           workflow_conclusion: completed
@@ -121,7 +121,7 @@ jobs:
           name: bfs-result
           path: bfs-result.json
       - name: Download the result
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v7
         with:
           workflow: compat.yml
           workflow_conclusion: completed
@@ -130,7 +130,7 @@ jobs:
           branch: main
           path: dl
       - name: Download the log
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v7
         with:
           workflow: compat.yml
           workflow_conclusion: completed

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           # Enable sources & install dependencies
-          sudo find /etc/apt/sources.list* -type f -exec sed -i 'p; s/^deb /deb-src /' '{}' +
+          sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
           sudo apt-get update
           sudo apt-get build-dep findutils
       - name: Run GNU tests

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -4,6 +4,9 @@ name: External-testsuites
 
 jobs:
   gnu-tests:
+    permissions:
+      actions: read
+
     name: Run GNU findutils tests
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +41,7 @@ jobs:
       - name: Extract testing info
         shell: bash
         run: |
+
       - name: Upload gnu-test-report
         uses: actions/upload-artifact@v4
         with:
@@ -51,24 +55,43 @@ jobs:
         with:
           name: gnu-result
           path: gnu-result.json
-      - name: Download the result
-        uses: dawidd6/action-download-artifact@v7
+      - name: Download artifacts (gnu-result and gnu-test-report)
+        uses: actions/github-script@v7
         with:
-          workflow: compat.yml
-          workflow_conclusion: completed
-          name: gnu-result
-          repo: uutils/findutils
-          branch: main
-          path: dl
-      - name: Download the log
-        uses: dawidd6/action-download-artifact@v7
-        with:
-          workflow: compat.yml
-          workflow_conclusion: completed
-          name: gnu-test-report
-          repo: uutils/findutils
-          branch: main
-          path: dl
+          script: |
+            let fs = require('fs');
+            fs.mkdirSync('${{ github.workspace }}/dl', { recursive: true });
+
+            async function downloadArtifact(artifactName) {
+              // List all artifacts from the workflow run
+              let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{ github.run_id }},
+              });
+
+              // Find the specified artifact
+              let matchArtifact = artifacts.data.artifacts.find((artifact) => artifact.name === artifactName);
+              if (!matchArtifact) {
+                throw new Error(`Artifact "${artifactName}" not found.`);
+              }
+
+              // Download the artifact
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+
+              // Save the artifact to a file
+              fs.writeFileSync(`${{ github.workspace }}/dl/${artifactName}.zip`, Buffer.from(download.data));
+            }
+
+            // Download the required artifacts
+            await downloadArtifact("gnu-result");
+            await downloadArtifact("gnu-test-report");
+
       - name: Compare failing tests against master
         shell: bash
         run: |
@@ -76,6 +99,8 @@ jobs:
       - name: Compare against main results
         shell: bash
         run: |
+          unzip dl/gnu-result.zip -d dl/
+          unzip dl/gnu-test-report.zip -d dl/
           mv dl/gnu-result.json latest-gnu-result.json
           python findutils/util/compare_gnu_result.py
 
@@ -120,24 +145,42 @@ jobs:
         with:
           name: bfs-result
           path: bfs-result.json
-      - name: Download the result
-        uses: dawidd6/action-download-artifact@v7
+      - name: Download artifacts (gnu-result and bfs-test-report)
+        uses: actions/github-script@v7
         with:
-          workflow: compat.yml
-          workflow_conclusion: completed
-          name: bfs-result
-          repo: uutils/findutils
-          branch: main
-          path: dl
-      - name: Download the log
-        uses: dawidd6/action-download-artifact@v7
-        with:
-          workflow: compat.yml
-          workflow_conclusion: completed
-          name: bfs-test-report
-          repo: uutils/findutils
-          branch: main
-          path: dl
+          script: |
+            let fs = require('fs');
+            fs.mkdirSync('${{ github.workspace }}/dl', { recursive: true });
+
+            async function downloadArtifact(artifactName) {
+              // List all artifacts from the workflow run
+              let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{ github.run_id }},
+              });
+
+              // Find the specified artifact
+              let matchArtifact = artifacts.data.artifacts.find((artifact) => artifact.name === artifactName);
+              if (!matchArtifact) {
+                throw new Error(`Artifact "${artifactName}" not found.`);
+              }
+
+              // Download the artifact
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+
+              // Save the artifact to a file
+              fs.writeFileSync(`${{ github.workspace }}/dl/${artifactName}.zip`, Buffer.from(download.data));
+            }
+
+            // Download the required artifacts
+            await downloadArtifact("bfs-result");
+            await downloadArtifact("bfs-test-report");
       - name: Compare failing tests against main
         shell: bash
         run: |
@@ -145,6 +188,8 @@ jobs:
       - name: Compare against main results
         shell: bash
         run: |
+          unzip dl/bfs-result.zip -d dl/
+          unzip dl/bfs-test-report.zip -d dl/
           mv dl/bfs-result.json latest-bfs-result.json
           python findutils/util/compare_bfs_result.py
 

--- a/src/find/matchers/logical_matchers.rs
+++ b/src/find/matchers/logical_matchers.rs
@@ -356,7 +356,6 @@ impl Matcher for NotMatcher {
 }
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use crate::find::matchers::quit::QuitMatcher;

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -143,7 +143,7 @@ pub struct MatcherIO<'a> {
     deps: &'a dyn Dependencies,
 }
 
-impl<'a> MatcherIO<'a> {
+impl MatcherIO<'_> {
     pub fn new(deps: &dyn Dependencies) -> MatcherIO<'_> {
         MatcherIO {
             should_skip_dir: false,

--- a/src/find/matchers/prune.rs
+++ b/src/find/matchers/prune.rs
@@ -24,8 +24,8 @@ impl Matcher for PruneMatcher {
         true
     }
 }
-#[cfg(test)]
 
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::find::matchers::tests::get_dir_entry_for;


### PR DESCRIPTION
Closed #483 #463

- Replace the `Enable sources & install dependencies` step with the enable deb-src sources instructions for Ubuntu 24.04. #483
- Remove the `dawidd6/action-download-artifact@v6` component and use js to access the GitHub API to download the artifact. #463
- Fix several issues with `cargo clippy --all-targets -- -D warnings`.