### PR TITLE
find: fix "unused import" warning on Windows

### DIFF
--- a/src/find/matchers/fs.rs
+++ b/src/find/matchers/fs.rs
@@ -3,6 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use super::{Matcher, MatcherIO, WalkEntry};
+#[cfg(unix)]
 use uucore::error::UResult;
 
 /// The latest mapping from dev_id to fs_type, used for saving mount info reads
@@ -30,6 +31,7 @@ use std::{
     io::{stderr, Write},
     path::Path,
 };
+
 #[cfg(unix)]
 pub fn get_file_system_type(path: &Path, cache: &RefCell<Option<Cache>>) -> UResult<String> {
     use std::os::unix::fs::MetadataExt;


### PR DESCRIPTION
This PR fixes an "unused import" warning on Windows, see, for example, https://github.com/uutils/findutils/actions/runs/13512703858/job/37755835852?pr=496#step:6:181.