### PR TITLE
Remove unused `once_cell` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,6 @@ dependencies = [
  "faccess",
  "filetime",
  "nix",
- "once_cell",
  "onig",
  "predicates",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ clap = "4.5"
 faccess = "0.2.4"
 walkdir = "2.5"
 regex = "1.11"
-once_cell = "1.20"
 onig = { version = "6.4", default-features = false }
 uucore = { version = "0.0.29", features = ["entries", "fs", "fsext", "mode"] }
 nix = { version = "0.29", features = ["fs", "user"] }


### PR DESCRIPTION
This PR removes the `once_cell` dependency as we no longer use it as a direct dependency.
