### PR TITLE
-name / should match ///

### DIFF
--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -23,6 +23,9 @@ impl NameMatcher {
 impl Matcher for NameMatcher {
     fn matches(&self, file_info: &WalkEntry, _: &mut MatcherIO) -> bool {
         let name = file_info.file_name().to_string_lossy();
+        if name.contains('/') {
+            return true;
+        }
         self.pattern.matches(&name)
     }
 }


### PR DESCRIPTION
Hi, I did some tests and the problem in https://github.com/uutils/findutils/issues/24 is because when we pass the './target/debug/find /// -maxdepth 0 -name /' it returns false. 
```rust
impl Matcher for NameMatcher {
    fn matches(&self, file_info: &WalkEntry, _: &mut MatcherIO) -> bool {
         let name = file_info.file_name().to_string_lossy();
        self.pattern.matches(&name)
    }
}
```
I put an early return as an alternative solution, but I don't know if it's a good solution.
