### PR TITLE
bugfix: Reuse the same file pointer for repeated `find` output (#439)

### DIFF
--- a/src/find/matchers/ls.rs
+++ b/src/find/matchers/ls.rs
@@ -7,6 +7,7 @@ use chrono::DateTime;
 use std::{
     fs::File,
     io::{stderr, Write},
+    sync::Arc,
 };
 
 use super::{Matcher, MatcherIO, WalkEntry};
@@ -110,11 +111,11 @@ fn format_permissions(file_attributes: u32) -> String {
 }
 
 pub struct Ls {
-    output_file: Option<File>,
+    output_file: Option<Arc<File>>,
 }
 
 impl Ls {
-    pub fn new(output_file: Option<File>) -> Self {
+    pub fn new(output_file: Option<Arc<File>>) -> Self {
         Self { output_file }
     }
 
@@ -256,7 +257,7 @@ impl Ls {
 impl Matcher for Ls {
     fn matches(&self, file_info: &WalkEntry, matcher_io: &mut MatcherIO) -> bool {
         if let Some(file) = &self.output_file {
-            self.print(file_info, file, true);
+            self.print(file_info, file.clone(), true);
         } else {
             self.print(
                 file_info,

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -35,8 +35,10 @@ use ::regex::Regex;
 use chrono::{DateTime, Datelike, NaiveDateTime, Utc};
 use fs::FileSystemMatcher;
 use ls::Ls;
+use std::collections::HashMap;
 use std::fs::{File, Metadata};
 use std::path::Path;
+use std::sync::Arc;
 use std::time::SystemTime;
 use std::{error::Error, str::FromStr};
 
@@ -268,13 +270,39 @@ impl ComparableValue {
     }
 }
 
+// Used on file output arguments.
+// When the same file is specified multiple times, the same pointer is used.
+struct FileMemoizer {
+    mem: HashMap<String, Arc<File>>
+}
+impl FileMemoizer {
+    fn new() -> Self {
+        Self { mem: HashMap::new() }
+    }
+    fn get_or_create_file(&mut self, path: &str) -> Result<Arc<File>, Box<dyn Error>> {
+        let file = self.mem.entry(path.to_string()).or_insert(
+            Arc::new(File::create(path)?)
+        );
+        Ok(file.clone())
+    }
+}
+
 /// Builds a single `AndMatcher` containing the Matcher objects corresponding
 /// to the passed in predicate arguments.
 pub fn build_top_level_matcher(
     args: &[&str],
     config: &mut Config,
 ) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
-    let (_, top_level_matcher) = (build_matcher_tree(args, config, 0, false))?;
+    let mut file_mem = FileMemoizer::new();
+    let (_, top_level_matcher) = (
+        build_matcher_tree(
+            args,
+            config,
+            &mut file_mem,
+            0,
+            false
+        )
+    )?;
 
     // if the matcher doesn't have any side-effects, then we default to printing
     if !top_level_matcher.has_side_effects() {
@@ -431,6 +459,7 @@ fn get_or_create_file(path: &str) -> Result<File, Box<dyn Error>> {
 fn build_matcher_tree(
     args: &[&str],
     config: &mut Config,
+    file_mem: &mut FileMemoizer,
     arg_index: usize,
     mut expecting_bracket: bool,
 ) -> Result<(usize, Box<dyn Matcher>), Box<dyn Error>> {
@@ -461,8 +490,10 @@ fn build_matcher_tree(
                 }
                 i += 1;
 
-                let file = get_or_create_file(args[i])?;
-                Some(Printer::new(PrintDelimiter::Newline, Some(file)).into_box())
+                let file = file_mem.get_or_create_file(args[i])?.clone();
+                Some(
+                    Printer::new(PrintDelimiter::Newline, Some(file)).into_box()
+                )
             }
             "-fprintf" => {
                 if i >= args.len() - 2 {
@@ -473,9 +504,11 @@ fn build_matcher_tree(
                 // Args + 1: output file path
                 // Args + 2: format string
                 i += 1;
-                let file = get_or_create_file(args[i])?;
+                let file = file_mem.get_or_create_file(args[i])?.clone();
                 i += 1;
-                Some(Printf::new(args[i], Some(file))?.into_box())
+                Some(
+                    Printf::new(args[i], Some(file))?.into_box()
+                )
             }
             "-fprint0" => {
                 if i >= args.len() - 1 {
@@ -483,8 +516,10 @@ fn build_matcher_tree(
                 }
                 i += 1;
 
-                let file = get_or_create_file(args[i])?;
-                Some(Printer::new(PrintDelimiter::Null, Some(file)).into_box())
+                let file = file_mem.get_or_create_file(args[i])?.clone();
+                Some(
+                    Printer::new(PrintDelimiter::Null, Some(file)).into_box()
+                )
             }
             "-ls" => Some(Ls::new(None).into_box()),
             "-fls" => {
@@ -811,7 +846,7 @@ fn build_matcher_tree(
                 None
             }
             "(" => {
-                let (new_arg_index, sub_matcher) = build_matcher_tree(args, config, i + 1, true)?;
+                let (new_arg_index, sub_matcher) = build_matcher_tree(args, config, file_mem, i + 1, true)?;
                 i = new_arg_index;
                 Some(sub_matcher)
             }

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -273,16 +273,19 @@ impl ComparableValue {
 // Used on file output arguments.
 // When the same file is specified multiple times, the same pointer is used.
 struct FileMemoizer {
-    mem: HashMap<String, Arc<File>>
+    mem: HashMap<String, Arc<File>>,
 }
 impl FileMemoizer {
     fn new() -> Self {
-        Self { mem: HashMap::new() }
+        Self {
+            mem: HashMap::new(),
+        }
     }
     fn get_or_create_file(&mut self, path: &str) -> Result<Arc<File>, Box<dyn Error>> {
-        let file = self.mem.entry(path.to_string()).or_insert(
-            Arc::new(File::create(path)?)
-        );
+        let file = self
+            .mem
+            .entry(path.to_string())
+            .or_insert(Arc::new(File::create(path)?));
         Ok(file.clone())
     }
 }
@@ -294,15 +297,7 @@ pub fn build_top_level_matcher(
     config: &mut Config,
 ) -> Result<Box<dyn Matcher>, Box<dyn Error>> {
     let mut file_mem = FileMemoizer::new();
-    let (_, top_level_matcher) = (
-        build_matcher_tree(
-            args,
-            config,
-            &mut file_mem,
-            0,
-            false
-        )
-    )?;
+    let (_, top_level_matcher) = (build_matcher_tree(args, config, &mut file_mem, 0, false))?;
 
     // if the matcher doesn't have any side-effects, then we default to printing
     if !top_level_matcher.has_side_effects() {
@@ -491,9 +486,7 @@ fn build_matcher_tree(
                 i += 1;
 
                 let file = file_mem.get_or_create_file(args[i])?.clone();
-                Some(
-                    Printer::new(PrintDelimiter::Newline, Some(file)).into_box()
-                )
+                Some(Printer::new(PrintDelimiter::Newline, Some(file)).into_box())
             }
             "-fprintf" => {
                 if i >= args.len() - 2 {
@@ -506,9 +499,7 @@ fn build_matcher_tree(
                 i += 1;
                 let file = file_mem.get_or_create_file(args[i])?.clone();
                 i += 1;
-                Some(
-                    Printf::new(args[i], Some(file))?.into_box()
-                )
+                Some(Printf::new(args[i], Some(file))?.into_box())
             }
             "-fprint0" => {
                 if i >= args.len() - 1 {
@@ -517,9 +508,7 @@ fn build_matcher_tree(
                 i += 1;
 
                 let file = file_mem.get_or_create_file(args[i])?.clone();
-                Some(
-                    Printer::new(PrintDelimiter::Null, Some(file)).into_box()
-                )
+                Some(Printer::new(PrintDelimiter::Null, Some(file)).into_box())
             }
             "-ls" => Some(Ls::new(None).into_box()),
             "-fls" => {
@@ -846,7 +835,8 @@ fn build_matcher_tree(
                 None
             }
             "(" => {
-                let (new_arg_index, sub_matcher) = build_matcher_tree(args, config, file_mem, i + 1, true)?;
+                let (new_arg_index, sub_matcher) =
+                    build_matcher_tree(args, config, file_mem, i + 1, true)?;
                 i = new_arg_index;
                 Some(sub_matcher)
             }

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -440,13 +440,6 @@ fn parse_str_to_newer_args(input: &str) -> Option<(String, String)> {
     }
 }
 
-/// Creates a file if it doesn't exist.
-/// If it does exist, it will be overwritten.
-fn get_or_create_file(path: &str) -> Result<File, Box<dyn Error>> {
-    let file = File::create(path)?;
-    Ok(file)
-}
-
 /// The main "translate command-line args into a matcher" function. Will call
 /// itself recursively if it encounters an opening bracket. A successful return
 /// consists of a tuple containing the new index into the args array to use (if
@@ -517,7 +510,7 @@ fn build_matcher_tree(
                 }
                 i += 1;
 
-                let file = get_or_create_file(args[i])?;
+                let file = file_mem.get_or_create_file(args[i])?.clone();
                 Some(Ls::new(Some(file)).into_box())
             }
             "-true" => Some(TrueMatcher.into_box()),
@@ -1703,31 +1696,5 @@ mod tests {
         build_top_level_matcher(&["(", "-version", "-o", ")", ")"], &mut config)
             .expect("-version should stop parsing");
         assert!(config.version_requested);
-    }
-
-    #[test]
-    fn get_or_create_file_test() {
-        use std::fs;
-
-        // remove file if hard link file exist.
-        // But you can't delete a file that doesn't exist,
-        // so ignore the error returned here.
-        let _ = fs::remove_file("test_data/get_or_create_file_test");
-
-        // test create file
-        let file = get_or_create_file("test_data/get_or_create_file_test");
-        assert!(file.is_ok());
-
-        let file = get_or_create_file("test_data/get_or_create_file_test");
-        assert!(file.is_ok());
-
-        // test error when file no permission
-        #[cfg(unix)]
-        {
-            let result = get_or_create_file("/etc/shadow");
-            assert!(result.is_err());
-        }
-
-        let _ = fs::remove_file("test_data/get_or_create_file_test");
     }
 }

--- a/src/find/matchers/printer.rs
+++ b/src/find/matchers/printer.rs
@@ -6,6 +6,7 @@
 
 use std::fs::File;
 use std::io::{stderr, Write};
+use std::sync::Arc;
 
 use super::{Matcher, MatcherIO, WalkEntry};
 
@@ -26,11 +27,11 @@ impl std::fmt::Display for PrintDelimiter {
 /// This matcher just prints the name of the file to stdout.
 pub struct Printer {
     delimiter: PrintDelimiter,
-    output_file: Option<File>,
+    output_file: Option<Arc<File>>,
 }
 
 impl Printer {
-    pub fn new(delimiter: PrintDelimiter, output_file: Option<File>) -> Self {
+    pub fn new(delimiter: PrintDelimiter, output_file: Option<Arc<File>>) -> Self {
         Self {
             delimiter,
             output_file,
@@ -65,7 +66,7 @@ impl Printer {
 impl Matcher for Printer {
     fn matches(&self, file_info: &WalkEntry, matcher_io: &mut MatcherIO) -> bool {
         if let Some(file) = &self.output_file {
-            self.print(file_info, file, true);
+            self.print(file_info, file.clone(), true);
         } else {
             self.print(
                 file_info,
@@ -120,7 +121,7 @@ mod tests {
         let dev_full = File::open("/dev/full").unwrap();
         let abbbc = get_dir_entry_for("./test_data/simple", "abbbc");
 
-        let matcher = Printer::new(PrintDelimiter::Newline, Some(dev_full));
+        let matcher = Printer::new(PrintDelimiter::Newline, Some(Arc::new(dev_full)));
         let deps = FakeDependencies::new();
 
         assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -7,6 +7,7 @@
 use std::error::Error;
 use std::fs::{self, File};
 use std::path::Path;
+use std::sync::Arc;
 use std::time::SystemTime;
 use std::{borrow::Cow, io::Write};
 
@@ -577,11 +578,11 @@ fn format_directive<'entry>(
 /// find's printf syntax.
 pub struct Printf {
     format: FormatString,
-    output_file: Option<File>,
+    output_file: Option<Arc<File>>,
 }
 
 impl Printf {
-    pub fn new(format: &str, output_file: Option<File>) -> Result<Self, Box<dyn Error>> {
+    pub fn new(format: &str, output_file: Option<Arc<File>>) -> Result<Self, Box<dyn Error>> {
         Ok(Self {
             format: FormatString::parse(format)?,
             output_file,
@@ -629,7 +630,7 @@ impl Printf {
 impl Matcher for Printf {
     fn matches(&self, file_info: &WalkEntry, matcher_io: &mut MatcherIO) -> bool {
         if let Some(file) = &self.output_file {
-            self.print(file_info, file);
+            self.print(file_info, file.clone());
         } else {
             self.print(file_info, &mut *matcher_io.deps.get_output().borrow_mut());
         }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -1007,7 +1007,7 @@ fn find_fprinter() {
 struct TestCaseData {
     search_dir: &'static str,
     args: Vec<&'static str>,
-    expected_out: &'static str
+    expected_out: &'static str,
 }
 
 #[test]

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -12,6 +12,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use regex::Regex;
 use serial_test::serial;
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::{env, io::ErrorKind};
@@ -1000,6 +1001,55 @@ fn find_fprinter() {
         assert!(contents.contains("test_data/simple"));
 
         let _ = fs::remove_file(format!("test_data/find_{p}"));
+    }
+}
+
+struct TestCaseData {
+    search_dir: &'static str,
+    args: Vec<&'static str>,
+    expected_out: &'static str
+}
+
+#[test]
+#[serial(working_dir)]
+fn find_using_same_out_multiple_times() {
+    let cases = HashMap::from([
+        ("fprint", TestCaseData{
+            search_dir: "test_data/simple",
+            args: vec!["-fprint", "test_data/find_fprint", "-fprint", "test_data/find_fprint"],
+            expected_out: "test_data/simple\ntest_data/simple\ntest_data/simple/subdir\ntest_data/simple/subdir\ntest_data/simple/subdir/ABBBC\ntest_data/simple/subdir/ABBBC\ntest_data/simple/abbbc\ntest_data/simple/abbbc\n"
+        }),
+        ("fprint0", TestCaseData{
+            search_dir: "test_data/simple",
+            args: vec!["-fprint0", "test_data/find_fprint0", "-fprint0", "test_data/find_fprint0"],
+            expected_out: "test_data/simple\0test_data/simple\0test_data/simple/subdir\0test_data/simple/subdir\0test_data/simple/subdir/ABBBC\0test_data/simple/subdir/ABBBC\0test_data/simple/abbbc\0test_data/simple/abbbc\0"
+        }),
+        ("fprintf", TestCaseData{
+            search_dir: "test_data/simple",
+            args: vec!["-fprintf", "test_data/find_fprintf", "%p\n", "-fprintf", "test_data/find_fprintf", "%f\n"],
+            expected_out: "test_data/simple\nsimple\ntest_data/simple/subdir\nsubdir\ntest_data/simple/subdir/ABBBC\nABBBC\ntest_data/simple/abbbc\nabbbc\n"
+        }),
+    ]);
+
+    for (key, test_data) in cases {
+        let _ = fs::remove_file(format!("test_data/find_{key}"));
+
+        Command::cargo_bin("find")
+            .expect("found binary")
+            .arg(test_data.search_dir)
+            .args(test_data.args)
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::is_empty());
+
+        // Read the generated content
+        let mut f = File::open(format!("test_data/find_{key}")).unwrap();
+        let mut contents = String::new();
+        f.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, test_data.expected_out);
+
+        let _ = fs::remove_file(format!("test_data/find_{key}"));
     }
 }
 


### PR DESCRIPTION
This PR creates a kind of memoization to the file creation inside the findutils/find command.
Uses a hashmap to know which file paths already has been created and returns the Arc<File> to prevent overwrite.

It also add a new testing function `find_using_same_out_multiple_times` to these more "complex" cases.
But, the expected outputs are fixed, if the assert would be better by catching the expected value dynamically in case of the test_data/simple structure change, let me know!