### PR TITLE
Fix incorrect triple slashes behavior

### DIFF
--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -25,11 +25,11 @@ impl Matcher for NameMatcher {
         let name = file_info.file_name().to_string_lossy();
 
         #[cfg(unix)]
-        if name.contains('/') {
-            return true;
+        if name.len() > 1 && name.chars().all(|x| x == '/') {
+            self.pattern.matches("/")
+        } else {
+            self.pattern.matches(&name)
         }
-
-        self.pattern.matches(&name)
     }
 }
 
@@ -135,8 +135,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn slash_match_returns_true() {
-        let dir_to_match = get_dir_entry_for("/", "");
-        let matcher = NameMatcher::new("///", true);
+        let dir_to_match = get_dir_entry_for("///", "");
+        let matcher = NameMatcher::new("/", true);
         let deps = FakeDependencies::new();
         assert!(matcher.matches(&dir_to_match, &mut deps.new_matcher_io()));
     }

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -30,6 +30,9 @@ impl Matcher for NameMatcher {
         } else {
             self.pattern.matches(&name)
         }
+
+        #[cfg(windows)]
+        self.pattern.matches(&name)
     }
 }
 

--- a/src/find/matchers/name.rs
+++ b/src/find/matchers/name.rs
@@ -143,4 +143,13 @@ mod tests {
         let deps = FakeDependencies::new();
         assert!(matcher.matches(&dir_to_match, &mut deps.new_matcher_io()));
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn only_one_slash() {
+        let dir_to_match = get_dir_entry_for("/", "");
+        let matcher = NameMatcher::new("/", false);
+        let deps = FakeDependencies::new();
+        assert!(matcher.matches(&dir_to_match, &mut deps.new_matcher_io()));
+    }
 }


### PR DESCRIPTION
As stated by @tavianator, the correct behavior of -name / is:

```
$ find / -maxdepth 0 -name /
/
$ find /// -maxdepth 0 -name /
///
$ find / -maxdepth 0 -name ///
$ find /// -maxdepth 0 -name ///
```
This PR meets the specified requirements. Now the issue https://github.com/uutils/findutils/issues/24 can be closed. 