### PR TITLE
find: Use matcher_io.set_exit_code()

### DIFF
--- a/src/find/matchers/ls.rs
+++ b/src/find/matchers/ls.rs
@@ -119,7 +119,13 @@ impl Ls {
     }
 
     #[cfg(unix)]
-    fn print(&self, file_info: &WalkEntry, mut out: impl Write, print_error_message: bool) {
+    fn print(
+        &self,
+        file_info: &WalkEntry,
+        matcher_io: &mut MatcherIO,
+        mut out: impl Write,
+        print_error_message: bool,
+    ) {
         use nix::unistd::{Gid, Group, Uid, User};
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
@@ -183,14 +189,20 @@ impl Ls {
                         e
                     )
                     .unwrap();
-                    uucore::error::set_exit_code(1);
+                    matcher_io.set_exit_code(1);
                 }
             }
         }
     }
 
     #[cfg(windows)]
-    fn print(&self, file_info: &WalkEntry, mut out: impl Write, print_error_message: bool) {
+    fn print(
+        &self,
+        file_info: &WalkEntry,
+        matcher_io: &mut MatcherIO,
+        mut out: impl Write,
+        print_error_message: bool,
+    ) {
         use std::os::windows::fs::MetadataExt;
 
         let metadata = file_info.metadata().unwrap();
@@ -246,7 +258,7 @@ impl Ls {
                         e
                     )
                     .unwrap();
-                    uucore::error::set_exit_code(1);
+                    matcher_io.set_exit_code(1);
                 }
             }
         }
@@ -256,10 +268,11 @@ impl Ls {
 impl Matcher for Ls {
     fn matches(&self, file_info: &WalkEntry, matcher_io: &mut MatcherIO) -> bool {
         if let Some(file) = &self.output_file {
-            self.print(file_info, file, true);
+            self.print(file_info, matcher_io, file, true);
         } else {
             self.print(
                 file_info,
+                matcher_io,
                 &mut *matcher_io.deps.get_output().borrow_mut(),
                 false,
             );

--- a/src/find/matchers/printer.rs
+++ b/src/find/matchers/printer.rs
@@ -37,7 +37,13 @@ impl Printer {
         }
     }
 
-    fn print(&self, file_info: &WalkEntry, mut out: impl Write, print_error_message: bool) {
+    fn print(
+        &self,
+        file_info: &WalkEntry,
+        matcher_io: &mut MatcherIO,
+        mut out: impl Write,
+        print_error_message: bool,
+    ) {
         match write!(
             out,
             "{}{}",
@@ -54,7 +60,7 @@ impl Printer {
                         e
                     )
                     .unwrap();
-                    uucore::error::set_exit_code(1);
+                    matcher_io.set_exit_code(1);
                 }
             }
         }
@@ -65,10 +71,11 @@ impl Printer {
 impl Matcher for Printer {
     fn matches(&self, file_info: &WalkEntry, matcher_io: &mut MatcherIO) -> bool {
         if let Some(file) = &self.output_file {
-            self.print(file_info, file, true);
+            self.print(file_info, matcher_io, file, true);
         } else {
             self.print(
                 file_info,
+                matcher_io,
                 &mut *matcher_io.deps.get_output().borrow_mut(),
                 false,
             );
@@ -124,11 +131,6 @@ mod tests {
         let deps = FakeDependencies::new();
 
         assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));
-
-        // Reset the exit code global variable in case we run another test after this one
-        // See https://github.com/uutils/coreutils/issues/5777
-        uucore::error::set_exit_code(0);
-
         assert!(deps.get_output_as_string().is_empty());
     }
 }


### PR DESCRIPTION
The uucore function has the downside of leaking the failure state
between unrelated tests, because the exit code is global.  PR #436
introduced a method on MatcherIO which solves the problem, but future
PRs added new uses of uucore::error::set_exit_code().
