### PR TITLE
clippy: fix warnings from Rust 1.86

### DIFF
--- a/src/find/matchers/entry.rs
+++ b/src/find/matchers/entry.rs
@@ -278,7 +278,7 @@ impl WalkEntry {
             Entry::Explicit(path, _) => {
                 // Path::file_name() only works if the last component is normal
                 path.components()
-                    .last()
+                    .next_back()
                     .map(|c| c.as_os_str())
                     .unwrap_or_else(|| path.as_os_str())
             }

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -401,7 +401,7 @@ fn format_directive<'entry>(
             // even though it's arguably not 100% correct.
             if *large_blocks {
                 // Ceiling divide in half.
-                (blocks + 1) / 2
+                blocks.div_ceil(2)
             } else {
                 blocks
             }

--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -799,11 +799,13 @@ fn normalize_options<'a>(
             );
                 let lines_index = matches
                     .indices_of(options::MAX_LINES)
-                    .and_then(|v| v.last());
-                let args_index = matches.indices_of(options::MAX_ARGS).and_then(|v| v.last());
+                    .and_then(|mut v| v.next_back());
+                let args_index = matches
+                    .indices_of(options::MAX_ARGS)
+                    .and_then(|mut v| v.next_back());
                 let replace_index = [options::REPLACE, options::REPLACE_I]
                     .iter()
-                    .flat_map(|o| matches.indices_of(o).and_then(|v| v.last()))
+                    .flat_map(|o| matches.indices_of(o).and_then(|mut v| v.next_back()))
                     .max();
                 if lines_index > args_index && lines_index > replace_index {
                     (None, options.max_lines, &None)
@@ -817,8 +819,8 @@ fn normalize_options<'a>(
 
     let delimiter = match (options.delimiter, options.null) {
         (Some(delimiter), true) => {
-            if matches.indices_of(options::NULL).unwrap().last()
-                > matches.indices_of(options::DELIMITER).unwrap().last()
+            if matches.indices_of(options::NULL).unwrap().next_back()
+                > matches.indices_of(options::DELIMITER).unwrap().next_back()
             {
                 Some(b'\0')
             } else {


### PR DESCRIPTION
This PR fixes warnings from the [manual_div_ceil](https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil) and [double_ended_iterator_last](https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last) lints.