### PR TITLE
Implement : Chained Type matcher arguments

### DIFF
--- a/src/find/matchers/entry.rs
+++ b/src/find/matchers/entry.rs
@@ -24,7 +24,7 @@ enum Entry {
 }
 
 /// File types.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum FileType {
     Unknown,
     Fifo,

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -62,9 +62,7 @@ impl TypeMatcher {
 
 impl Matcher for TypeMatcher {
     fn matches(&self, file_info: &WalkEntry, _: &mut MatcherIO) -> bool {
-        self.file_type
-            .iter()
-            .any(|entry| *entry == file_info.file_type())
+        self.file_type.contains(&file_info.file_type())
     }
 }
 

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -4,15 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use std::error::Error;
-
 use super::{FileType, Follow, Matcher, MatcherIO, WalkEntry};
-
-type TypeList = std::collections::HashSet<FileType>;
+use std::collections::HashSet;
+use std::error::Error;
 
 /// This matcher checks the type of the file.
 pub struct TypeMatcher {
-    file_type: TypeList,
+    file_type: HashSet<FileType>,
 }
 
 fn parse(type_string: &str, mode: &str) -> Result<FileType, Box<dyn Error>> {
@@ -68,7 +66,7 @@ impl Matcher for TypeMatcher {
 
 /// Like [TypeMatcher], but toggles whether symlinks are followed.
 pub struct XtypeMatcher {
-    file_type: TypeList,
+    file_type: HashSet<FileType>,
 }
 
 impl XtypeMatcher {
@@ -103,7 +101,7 @@ impl Matcher for XtypeMatcher {
     }
 }
 
-fn type_creator(type_string: &str, mode: &str) -> Result<TypeList, Box<dyn Error>> {
+fn type_creator(type_string: &str, mode: &str) -> Result<HashSet<FileType>, Box<dyn Error>> {
     let mut file_types = std::collections::HashSet::new();
 
     if type_string.contains(',') {

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -87,7 +87,7 @@ impl Matcher for XtypeMatcher {
             Follow::Always
         };
 
-        let file_type_result = follow
+        let file_type = follow
             .metadata(file_info)
             .map(|m| m.file_type().into())
             .or_else(|e| {
@@ -99,7 +99,7 @@ impl Matcher for XtypeMatcher {
             })
             .unwrap_or(FileType::Unknown);
 
-        self.file_type.contains(&file_type_result)
+        self.file_type.contains(&file_type)
     }
 }
 

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -364,6 +364,6 @@ mod tests {
         //looping symlink
         let matcher2 = XtypeMatcher::new("l").unwrap();
         let looping_entry = get_dir_entry_for("test_data/links", "link-loop");
-        assert!(matcher2.matches(&looping_entry, &mut deps.new_matcher_io()))
+        assert!(matcher2.matches(&looping_entry, &mut deps.new_matcher_io()));
     }
 }

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -335,4 +335,14 @@ mod tests {
         let deps = FakeDependencies::new();
         assert!(matcher.matches(&entry, &mut deps.new_matcher_io()));
     }
+
+    #[test]
+    fn chained_arguments_type(){
+        assert!(TypeMatcher::new("").is_err());
+        assert!(TypeMatcher::new("f,f").is_err());
+        assert!(TypeMatcher::new("f,").is_err());
+        assert!(XtypeMatcher::new("").is_err());
+        assert!(XtypeMatcher::new("f,f").is_err());
+        assert!(XtypeMatcher::new("f,").is_err());
+    }
 }

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -10,7 +10,8 @@ use super::{FileType, Follow, Matcher, MatcherIO, WalkEntry};
 
 /// This matcher checks the type of the file.
 pub struct TypeMatcher {
-    file_type: FileType,
+    file_type: Option<FileType>,
+    chained_file_types: Option<Vec<FileType>>
 }
 
 fn parse(type_string: &str) -> Result<FileType, Box<dyn Error>> {
@@ -39,8 +40,24 @@ fn parse(type_string: &str) -> Result<FileType, Box<dyn Error>> {
 
 impl TypeMatcher {
     pub fn new(type_string: &str) -> Result<Self, Box<dyn Error>> {
-        let file_type = parse(type_string)?;
-        Ok(Self { file_type })
+        if type_string.contains(","){
+            let chained_type_list = type_string
+            .split(',')
+            .map(|s| {
+                if s.is_empty() {
+                    Err(From::from("Empty type in comma-separated list"))
+                } else {
+                    parse(s)
+                }
+            })
+            .collect::<Result<Vec<FileType>, _>>()?;
+        }else{
+            let single_file_type = parse(type_string)?;
+        }
+        Ok(Self { 
+            file_type:Some(),
+            chained_file_types:None 
+        })
     }
 }
 

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -109,18 +109,16 @@ fn type_creator(type_string: &str, mode: &str) -> Result<TypeList, Box<dyn Error
     let mut file_types = std::collections::HashSet::new();
 
     if type_string.contains(',') {
-        let mut seen = std::collections::HashSet::new();
-
         for part in type_string.split(',') {
             let trimmed = part.trim();
             if trimmed.is_empty() {
                 return Err(From::from(format!("find: Last file type in list argument to {mode} is missing, i.e., list is ending on: ','")));
-            } else if !seen.insert(trimmed) {
+            }
+            let file_type = parse(trimmed, mode)?;
+            if !file_types.insert(file_type) {
                 return Err(From::from(format!(
                     "Duplicate file type '{part}' in the argument list to {mode}"
                 )));
-            } else {
-                file_types.insert(parse(trimmed, mode)?);
             }
         }
     } else {

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -106,11 +106,10 @@ fn type_creator(type_string: &str, mode: &str) -> Result<HashSet<FileType>, Box<
 
     if type_string.contains(',') {
         for part in type_string.split(',') {
-            let trimmed = part.trim();
-            if trimmed.is_empty() {
+            if part.is_empty() {
                 return Err(From::from(format!("find: Last file type in list argument to {mode} is missing, i.e., list is ending on: ','")));
             }
-            let file_type = parse(trimmed, mode)?;
+            let file_type = parse(part, mode)?;
             if !file_types.insert(file_type) {
                 return Err(From::from(format!(
                     "Duplicate file type '{part}' in the argument list to {mode}"

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -114,7 +114,7 @@ impl Matcher for XtypeMatcher {
             false
         } else {
             // Single type check
-            let expected_type = self.file_type.unwrap(); // Safe due to struct invariants
+            let expected_type = self.file_type.unwrap();
             if let Ok(actual_type) = &file_type_result {
                 *actual_type == expected_type
             } else {
@@ -360,5 +360,10 @@ mod tests {
         // Broken symlink
         let broken_entry = get_dir_entry_for("test_data/links", "link-missing");
         assert!(matcher.matches(&broken_entry, &mut deps.new_matcher_io()));
+
+        //looping symlink
+        let matcher2 = XtypeMatcher::new("l").unwrap();
+        let looping_entry = get_dir_entry_for("test_data/links", "link-loop");
+        assert!(matcher2.matches(&looping_entry, &mut deps.new_matcher_io()))
     }
 }

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -337,7 +337,7 @@ mod tests {
     }
 
     #[test]
-    fn chained_arguments_type(){
+    fn chained_arguments_type() {
         assert!(TypeMatcher::new("").is_err());
         assert!(TypeMatcher::new("f,f").is_err());
         assert!(TypeMatcher::new("f,").is_err());

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -49,7 +49,7 @@ impl TypeMatcher {
         let mut chained_type_list: Option<Vec<FileType>> = None;
         if type_string.contains(',') {
             let mut seen = std::collections::HashSet::new();
-            
+
             chained_type_list = Some(
                 type_string
                     .split(',')
@@ -60,7 +60,7 @@ impl TypeMatcher {
                         } else if !seen.insert(trimmed) {
                             return Err(From::from(format!(
                                 "Duplicate file type '{s}' in the argument list to -type"
-                            )))
+                            )));
                         } else {
                             parse(trimmed)
                         }
@@ -68,6 +68,11 @@ impl TypeMatcher {
                     .collect::<Result<Vec<FileType>, _>>()?,
             );
         } else {
+            if type_string.len() > 1 {
+                return Err(From::from(
+                    "Must separate multiple arguments to -type using: ','",
+                ));
+            }
             single_file_type = Some(parse(type_string)?);
         }
         Ok(Self {
@@ -124,8 +129,6 @@ impl Matcher for XtypeMatcher {
         }
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -364,6 +364,7 @@ mod tests {
         //looping symlink
         let matcher2 = XtypeMatcher::new("l").unwrap();
         let looping_entry = get_dir_entry_for("test_data/links", "link-loop");
+        assert!(matcher.matches(&looping_entry, &mut deps.new_matcher_io()));
         assert!(matcher2.matches(&looping_entry, &mut deps.new_matcher_io()));
     }
 }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -74,6 +74,62 @@ fn two_matchers_one_matches() {
         .stdout(predicate::str::is_empty());
 }
 
+#[test]
+fn multiple_matcher_success() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-type", "f,d,l", "-name", "abbbc"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("abbbc"));
+}
+
+#[test]
+fn multiple_matcher_failure() {
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-type", "fd", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Must separate multiple arguments"))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-type", "f,", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("list is ending on: ','"))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-type", "f,f", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Duplicate file type"))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-type", "", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "should contain at least one letter",
+        ))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-type", "x,y", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Unrecognised type argument"))
+        .stdout(predicate::str::is_empty());
+}
+
 #[serial(working_dir)]
 #[test]
 fn files0_empty_file() {

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -83,6 +83,14 @@ fn multiple_matcher_success() {
         .success()
         .stderr(predicate::str::is_empty())
         .stdout(predicate::str::contains("abbbc"));
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-xtype", "f,d,l", "-name", "abbbc"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("abbbc"));
 }
 
 #[test]
@@ -124,6 +132,48 @@ fn multiple_matcher_failure() {
     Command::cargo_bin("find")
         .expect("found binary")
         .args(["-type", "x,y", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Unrecognised type argument"))
+        .stdout(predicate::str::is_empty());
+    // x-type tests below
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-xtype", "fd", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Must separate multiple arguments"))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-xtype", "f,", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("list is ending on: ','"))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-xtype", "f,f", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Duplicate file type"))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-xtype", "", "-name", "abbb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "should contain at least one letter",
+        ))
+        .stdout(predicate::str::is_empty());
+
+    Command::cargo_bin("find")
+        .expect("found binary")
+        .args(["-xtype", "x,y", "-name", "abbb"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("Unrecognised type argument"))


### PR DESCRIPTION
Refer - https://www.gnu.org/software/findutils/manual/html_node/find_html/Type.html

>As a GNU extension, multiple file types can be provided as a combined list separated by comma ‘,’. For example, ‘-type f,d,l’ is logically interpreted as ‘( -type f -o -type d -o -type l )’.