### PR TITLE
change "Error:" to "find:" + Testcase fix

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -720,7 +720,9 @@ fn build_matcher_tree(
                 i += 1;
                 let matcher = UserMatcher::from_user_name(user)
                     .or_else(|| Some(UserMatcher::from_uid(user.parse::<u32>().ok()?)))
-                    .ok_or_else(|| format!("{user} is not the name of a known user"))?;
+                    .ok_or_else(|| {
+                        format!("invalid user name or UID argument to -user: '{user}'")
+                    })?;
                 Some(matcher.into_box())
             }
             "-nouser" => Some(NoUserMatcher {}.into_box()),
@@ -749,7 +751,9 @@ fn build_matcher_tree(
                 i += 1;
                 let matcher = GroupMatcher::from_group_name(group)
                     .or_else(|| Some(GroupMatcher::from_gid(group.parse::<u32>().ok()?)))
-                    .ok_or_else(|| format!("{group} is not the name of an existing group"))?;
+                    .ok_or_else(|| {
+                        format!("invalid group name or GID argument to -group: '{group}'")
+                    })?;
                 Some(matcher.into_box())
             }
             "-nogroup" => Some(NoGroupMatcher {}.into_box()),

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -318,7 +318,7 @@ pub fn find_main(args: &[&str], deps: &dyn Dependencies) -> i32 {
     match do_find(&args[1..], deps) {
         Ok(ret) => ret,
         Err(e) => {
-            writeln!(&mut stderr(), "Error: {e}").unwrap();
+            writeln!(&mut stderr(), "find: {e}").unwrap();
             1
         }
     }

--- a/tests/find_cmd_tests.rs
+++ b/tests/find_cmd_tests.rs
@@ -851,7 +851,9 @@ fn find_with_user_predicate() {
         .args(["test_data", "-user", " "])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("is not the name of a known user"))
+        .stderr(predicate::str::contains(
+            "invalid user name or UID argument to -user",
+        ))
         .stdout(predicate::str::is_empty());
 }
 
@@ -921,7 +923,7 @@ fn find_with_group_predicate() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "is not the name of an existing group",
+            "invalid group name or GID argument to -group:",
         ))
         .stdout(predicate::str::is_empty());
 }
@@ -1035,7 +1037,7 @@ fn find_age_range() {
                 .failure()
                 .code(1)
                 .stderr(predicate::str::contains(
-                    "Error: Expected a decimal integer (with optional + or - prefix) argument to",
+                    "find: Expected a decimal integer (with optional + or - prefix) argument to",
                 ))
                 .stdout(predicate::str::is_empty());
         }


### PR DESCRIPTION
Changed the error format of 
```Error: .......```
to
```find: .......```
to match GNU and also help pass testsuite.

Also fixed an error message which was failing test in GNU Testsuite and it is now passing (`tests/find/user-group-max.sh`)