### PR TITLE
Fix compile error with `onig`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+# TODO remove when https://github.com/rust-onig/rust-onig/issues/196 is fixed
+CFLAGS='-std=gnu17'

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 target
 .gitignore
 .project
-.cargo
 .settings
 test_data/links/link-*
 /public/


### PR DESCRIPTION
After running `cargo clean` I got a compile error with `onig` due to GCC 15's move to a newer C standard (C23). This PR specifies to use the previous standard (C17).