### PR TITLE
Cargo.toml: Rename dist profile and add release-small

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,13 @@ path = "src/xargs/main.rs"
 name = "testing-commandline"
 path = "src/testing/commandline/main.rs"
 
-# The profile that 'cargo dist' will build with
-[profile.dist]
-inherits = "release"
+[profile.release]
 lto = "thin"
+codegen-units = 1
 
+[profile.release-fast]
+inherits = "release"
+panic = "abort"
 
 [lints.clippy]
 multiple_crate_versions = "allow"


### PR DESCRIPTION
It seems `--profile=dist` is not used at anywhere and distributor might miss the profile name.
1. Rename dist profile to release.
2. Add codegen-units to the profile.
3. Add release-fast profile as other uutils projects do. Closes #582