### PR TITLE
clippy: fix warning from `derivable_impls` lint

### DIFF
--- a/src/find/matchers/regex.rs
+++ b/src/find/matchers/regex.rs
@@ -30,8 +30,9 @@ impl fmt::Display for ParseRegexTypeError {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum RegexType {
+    #[default]
     Emacs,
     Grep,
     PosixBasic,
@@ -71,12 +72,6 @@ impl FromStr for RegexType {
             "ed" | "sed" => Ok(Self::PosixBasic),
             _ => Err(ParseRegexTypeError(s.to_owned())),
         }
-    }
-}
-
-impl Default for RegexType {
-    fn default() -> Self {
-        Self::Emacs
     }
 }
 


### PR DESCRIPTION
This PR fixes a clippy warning from the [derivable_impls](https://rust-lang.github.io/rust-clippy/stable/index.html#derivable_impls) lint that shows up after upgrading to Rust `1.91.0`.