### PR TITLE
find: fix warnings from `filter_next` lint

### DIFF
--- a/src/find/matchers/fs.rs
+++ b/src/find/matchers/fs.rs
@@ -53,8 +53,7 @@ pub fn get_file_system_type(path: &Path, cache: &RefCell<Option<Cache>>) -> URes
     let fs_list = uucore::fsext::read_fs_list()?;
     let result = fs_list
         .into_iter()
-        .filter(|fs| fs.dev_id == dev_id)
-        .next_back()
+        .rfind(|fs| fs.dev_id == dev_id)
         .map_or_else(String::new, |fs| fs.fs_type);
 
     // cache the latest query if not a match before

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -446,8 +446,7 @@ fn format_directive<'entry>(
                 uucore::fsext::read_fs_list().expect("Could not find the filesystem info");
             fs_list
                 .into_iter()
-                .filter(|fs| fs.dev_id == dev_id)
-                .next_back()
+                .rfind(|fs| fs.dev_id == dev_id)
                 .map_or_else(String::new, |fs| fs.fs_type)
                 .into()
         }


### PR DESCRIPTION
This PR fixes two warnings from the [filter_next](https://rust-lang.github.io/rust-clippy/stable/index.html#filter_next) lint that show up with Rust `1.92.0`.