### PR TITLE
xargs: accept hyphenated -I and -E values

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -1006,6 +1006,7 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
             Arg::new(options::REPLACE_I)
                 .short('I')
                 .num_args(1)
+                .allow_hyphen_values(true)
                 .value_name("R")
                 .help(
                     "Replace R in initial arguments with names read from standard input; \
@@ -1019,6 +1020,7 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
             Arg::new(options::EOF)
                 .short('E')
                 .num_args(1)
+                .allow_hyphen_values(true)
                 .value_name("eof-string")
                 .help(
                     "If specified, stop processing the input upon reaching an input \
@@ -1031,6 +1033,7 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
                 .short('e')
                 .long(options::EOF)
                 .num_args(0..=1)
+                .allow_hyphen_values(true)
                 .value_name("eof-string")
                 .help("Alias for -E")
                 .overrides_with(options::EOF)

--- a/tests/test_xargs.rs
+++ b/tests/test_xargs.rs
@@ -417,6 +417,12 @@ fn xargs_replace() {
         .succeeds()
         .stdout_contains("{} bar foo");
 
+    ucmd()
+        .args(&["-I", "-_", "echo", "-_ bar"])
+        .pipe_in("foo")
+        .succeeds()
+        .stdout_contains("foo bar");
+
     // Expected to fail
     ucmd()
         .args(&["-I", "echo", "_ _ bar"])
@@ -485,6 +491,12 @@ fn xargs_eof() {
             .succeeds()
             .stdout_only("ab\n");
     }
+
+    ucmd()
+        .args(&["-E", "-end"])
+        .pipe_in("ab -end ef")
+        .succeeds()
+        .stdout_only("ab\n");
 }
 
 #[test]


### PR DESCRIPTION
GNU xargs treats the arguments to -I, -E, and -e as values even when they begin with a hyphen. Clap was parsing those strings as options instead, so invocations like 'xargs -I -_' failed before xargs could process input.

Allow hyphen-leading values for those options and add regression coverage for replacement and EOF markers that start with '-'.