### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -359,7 +359,7 @@ dependencies = [
  "argmax",
  "chrono",
  "clap",
- "ctor 0.12.0",
+ "ctor 1.0.1",
  "faccess",
  "filetime",
  "nix 0.31.2",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
 
 [[package]]
 name = "linktime-proc-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ uucore = { version = "0.8.0", features = ["entries", "fs", "fsext", "mode"] }
 walkdir = "2.5"
 
 [dev-dependencies]
-ctor = "0.12"
+ctor = "1.0"
 filetime = "0.2"
 nix = { version = "0.31", features = ["fs"] }
 tempfile = "3"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,7 +12,7 @@ pub mod test_helpers;
 // Set UUTESTS_BINARY_PATH before any tests run. The value is only used by
 // TestScenario::new() to satisfy its internal setup; tests that need a
 // specific binary pass it explicitly via TestScenario::cmd(BINARY_PATH).
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     std::env::set_var("UUTESTS_BINARY_PATH", env!("CARGO_BIN_EXE_find"));
 }


### PR DESCRIPTION
This PR bumps `ctor` from `0.12.0` to <del>`1.0.0`</del>`1.0.1` and adapts `tests/common/mod.rs` to a change in `ctor`.