### PR TITLE
ci: deactivate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,5 @@ repos:
         pass_filenames: false
         types: [file, rust]
         language: system
+ci:
+  skip: [rust-linting, rust-clippy]


### PR DESCRIPTION
This PR deactivates the pre-commit hooks in the CI to get it back to green.