### PR TITLE
fix: avoid panic on -fprintf with missing arguments

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -469,7 +469,7 @@ fn build_matcher_tree(
                 Some(Printer::new(PrintDelimiter::Newline, Some(file)).into_box())
             }
             "-fprintf" => {
-                if i >= args.len() - 2 {
+                if i + 2 >= args.len() {
                     return Err(From::from(format!("missing argument to {}", args[i])));
                 }
 

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -986,6 +986,21 @@ fn find_fprintf() {
 }
 
 #[test]
+fn find_fprintf_missing_arguments() {
+    // Regression test: `-fprintf` with no file/format argument must report a
+    // missing-argument error instead of panicking (see issue #696).
+    ucmd()
+        .args(&["-fprintf"])
+        .fails()
+        .stderr_contains("missing argument to -fprintf");
+
+    ucmd()
+        .args(&["-fprintf", "/tmp/find_fprintf_out"])
+        .fails()
+        .stderr_contains("missing argument to -fprintf");
+}
+
+#[test]
 fn find_ls() {
     ucmd()
         .args(&["./test_data/simple/subdir", "-ls"])


### PR DESCRIPTION
Fixes #696