### PR TITLE
xargs: clarify -x and -t help text

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -918,8 +918,8 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
                 .short('x')
                 .long(options::EXIT)
                 .help(
-                    "Exit if the number of arguments allowed by -L or -n do not \
-                    fit into the number of allowed characters",
+                    "Terminate if a constructed command line would exceed the size \
+                    limit (see -s) rather than reducing the argument count",
                 )
                 .action(ArgAction::SetTrue),
         )
@@ -989,7 +989,7 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
             Arg::new(options::VERBOSE)
                 .short('t')
                 .long(options::VERBOSE)
-                .help("Be verbose")
+                .help("Print each command to stderr before executing it")
                 .action(ArgAction::SetTrue),
         )
         .arg(


### PR DESCRIPTION
The previous text implied -x only interacts with -L/-n and used imprecise phrasing. The new text mirrors the POSIX spec: terminate when a constructed command line would exceed the size limit rather than reducing the argument count.

Clarify that -t prints each command to stderr, rather than just "be verbose".