### PR TITLE
find: -printf: don't panic on a multibyte char after an octal escape

### DIFF
--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -167,16 +167,21 @@ impl FormatStringParser<'_> {
         // Try parsing an octal sequence first.
         let first = self.front()?;
         if first.is_digit(OCTAL_RADIX) {
-            if let Ok(code) = self.peek(OCTAL_LEN).and_then(|octal| {
-                u32::from_str_radix(octal, OCTAL_RADIX).map_err(std::convert::Into::into)
-            }) {
-                // safe to unwrap: .peek() already succeeded above.
-                let octal = self.advance_by(OCTAL_LEN).unwrap();
-                return match char::from_u32(code) {
-                    Some(c) => Ok(FormatComponent::Literal(c.to_string())),
-                    None => Err(format!("Invalid character value: \\{octal}").into()),
-                };
-            }
+            // A GNU octal escape is 1 to 3 octal digits. Consume only the leading
+            // octal digits (which are ASCII), rather than slicing a fixed 3 bytes
+            // that can land inside a following multibyte char.
+            let octal: String = self
+                .string
+                .chars()
+                .take(OCTAL_LEN)
+                .take_while(|c| c.is_digit(OCTAL_RADIX))
+                .collect();
+            let code = u32::from_str_radix(&octal, OCTAL_RADIX)?;
+            self.advance_by(octal.len())?;
+            return match char::from_u32(code) {
+                Some(c) => Ok(FormatComponent::Literal(c.to_string())),
+                None => Err(format!("Invalid character value: \\{octal}").into()),
+            };
         }
 
         self.advance_one()?;
@@ -686,6 +691,31 @@ mod tests {
 
         assert!(FormatString::parse("\\X").is_err());
         assert!(FormatString::parse("\\").is_err());
+    }
+
+    #[test]
+    fn test_parse_octal_escape_before_multibyte_char() {
+        assert_eq!(
+            FormatString::parse("\\0€").unwrap().components,
+            vec![
+                FormatComponent::Literal("\0".to_owned()),
+                FormatComponent::Literal("€".to_owned()),
+            ]
+        );
+        assert_eq!(
+            FormatString::parse("\\1😀").unwrap().components,
+            vec![
+                FormatComponent::Literal("\u{1}".to_owned()),
+                FormatComponent::Literal("😀".to_owned()),
+            ]
+        );
+        assert_eq!(
+            FormatString::parse("\\00é").unwrap().components,
+            vec![
+                FormatComponent::Literal("\0".to_owned()),
+                FormatComponent::Literal("é".to_owned()),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #720

`find -printf '\NNN'` octal escapes were parsed by slicing a fixed 3 bytes off the format string. When fewer than 3 octal digits are followed by a multibyte character (e.g. `-printf '\0€'`), that 3-byte slice lands inside the multibyte char and panics on a UTF-8 char-boundary assertion (exit 101); GNU `find` exits 0.

The octal escape is now parsed from its leading octal digits only (1 to 3, all ASCII) and the parser advances by their byte length, so a following multibyte char is never sliced into.

This also fixes `\1`..`\7`: previously only `\0` was recognised and `\1`..`\7` fell through to the single-character escape table and errored, instead of being treated as octal — now matching GNU `find`.

Verified byte-for-byte against GNU for `\0€`, `\1😀`, `\00é`, `\101`, `\012X`. Added a regression unit test.
