### PR TITLE
find: use GNU wording "unknown predicate" for unrecognized args

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -975,7 +975,7 @@ fn build_matcher_tree(
                             )
                         }
                     }
-                    None => return Err(From::from(format!("Unrecognized flag: '{}'", args[i]))),
+                    None => return Err(From::from(format!("unknown predicate '{}'", args[i]))),
                 }
             }
         };

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -546,7 +546,7 @@ mod tests {
         //
         let result = super::parse_args(&["-asdadsafsfsadcs"]);
         if let Err(e) = result {
-            assert_eq!(e.to_string(), "Unrecognized flag: '-asdadsafsfsadcs'");
+            assert_eq!(e.to_string(), "unknown predicate '-asdadsafsfsadcs'");
         } else {
             panic!("parse_args should have returned an error");
         }

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -83,6 +83,24 @@ fn multiple_matcher_success() {
 }
 
 #[test]
+fn unknown_predicate_is_rejected() {
+    // GNU find rejects an unrecognized predicate with
+    // "find: unknown predicate '<arg>'" and exit code 1 (see the GNU
+    // testsuite's tests/find/refuse-noop test).
+    ucmd()
+        .arg("-noop")
+        .fails()
+        .stderr_contains("unknown predicate '-noop'")
+        .no_stdout();
+
+    ucmd()
+        .arg("---noop")
+        .fails()
+        .stderr_contains("unknown predicate '---noop'")
+        .no_stdout();
+}
+
+#[test]
 fn multiple_matcher_failure() {
     ucmd()
         .args(&["-type", "fd", "-name", "abbb"])


### PR DESCRIPTION
GNU find rejects an unrecognized predicate with
"find: unknown predicate '<arg>'", but we printed
"find: Unrecognized flag: '<arg>'". Match GNU so the tests/find/refuse-noop GNU test (and others hitting the same path) pass. Add an integration test covering -noop and ---noop.