### PR TITLE
find: -printf: test octal escape before a multibyte char

### DIFF
--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -510,6 +510,15 @@ fn find_printf() {
         );
 }
 
+#[test]
+fn find_printf_octal_escape_before_multibyte_char() {
+    ucmd()
+        .args(&["./test_data/simple", "-maxdepth", "0", "-printf", "\\0€\\n"])
+        .succeeds()
+        .no_stderr()
+        .stdout_only("\0€\n");
+}
+
 #[cfg(unix)]
 #[test]
 fn find_perm() {


### PR DESCRIPTION
Follow-up to #723 (fixes #720): adds the integration test requested in review.

`-printf` octal escapes (`\NNN`) followed by a multibyte character used to slice the format string mid-char and panic. #723 fixed the parser; this adds a `tests/test_find.rs` regression test asserting `find … -printf '\0€\n'` succeeds and emits the escape byte plus the following character intact (`00 e2 82ac 0a`).
