### PR TITLE
find: -printf: advance past a full char in advance_one to avoid a multibyte panic

### DIFF
--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -152,7 +152,7 @@ impl FormatStringParser<'_> {
 
     fn advance_one(&mut self) -> Result<char, Box<dyn Error>> {
         let c = self.front()?;
-        self.string = &self.string[1..];
+        self.string = &self.string[c.len_utf8()..];
         Ok(c)
     }
 
@@ -725,6 +725,16 @@ mod tests {
                 FormatComponent::Literal("é".to_owned()),
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_multibyte_char_after_directive() {
+        assert_eq!(
+            FormatString::parse("%€").unwrap().components,
+            vec![FormatComponent::Literal("€".to_owned())]
+        );
+        assert!(FormatString::parse("\\€").is_err());
+        assert!(FormatString::parse("%A€").is_err());
     }
 
     #[test]

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -588,6 +588,22 @@ fn find_printf_width_too_large() {
         .stderr_contains("find: Invalid format width");
 }
 
+#[test]
+fn find_printf_multibyte_char_after_directive() {
+    ucmd()
+        .args(&["./test_data/simple", "-maxdepth", "0", "-printf", "%€\\n"])
+        .succeeds()
+        .stdout_only("€\n");
+    ucmd()
+        .args(&["./test_data/simple", "-maxdepth", "0", "-printf", "\\€\\n"])
+        .fails()
+        .stderr_contains("find: Invalid escape sequence");
+    ucmd()
+        .args(&["./test_data/simple", "-maxdepth", "0", "-printf", "%A€"])
+        .fails()
+        .stderr_contains("find: Invalid time specifier");
+}
+
 #[cfg(unix)]
 #[test]
 fn find_perm() {


### PR DESCRIPTION
Fixes #730

`advance_one` read a full `char` via `front()` but then dropped it by slicing one byte (`&self.string[1..]`). When that char is multibyte (e.g. `€` after a `%` conversion, a `\` escape, or a `%A`/`%C`/`%T` time directive), byte index 1 is not a char boundary, so the slice panicked:

```console
$ mkdir d; touch d/a
$ find d -printf '%€\n'
thread 'main' panicked at src/find/matchers/printf.rs:152:35:
byte index 1 is not a char boundary; it is inside '€' (bytes 0..3) of `€`
$ echo $?
101
```

(also `\€` and `%A€` / `%C€` / `%T€`)

This advances by the leading char's UTF-8 length (`c.len_utf8()`) instead of a fixed `1`, so a multibyte char routes through the normal handling instead of aborting — the same multibyte-aware approach #723 applied to `peek`. Unrecognized escapes / invalid time specifiers keep their existing behavior (a multibyte char now behaves exactly like its ASCII equivalent, e.g. `\€` like `\q`).

Added a regression test (`test_parse_multibyte_char_after_directive`).
