### PR TITLE
find: -printf: reject an over-large field width instead of panicking

### DIFF
--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -207,7 +207,7 @@ impl FormatStringParser<'_> {
         }
     }
 
-    fn parse_format_width(&mut self) -> Option<usize> {
+    fn parse_format_width(&mut self) -> Result<Option<usize>, Box<dyn Error>> {
         let start = self.string;
         let mut digits = 0;
 
@@ -218,11 +218,16 @@ impl FormatStringParser<'_> {
         }
 
         if digits > 0 {
-            // safe to unwrap: we already know all the digits are valid due to
-            // the above checks.
-            Some((start[0..digits]).parse().unwrap())
+            let digits = &start[0..digits];
+            let width: usize = digits
+                .parse()
+                .map_err(|_| format!("Invalid format width: {digits}"))?;
+            if width > u16::MAX as usize {
+                return Err(format!("Format width too large: {digits}").into());
+            }
+            Ok(Some(width))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -258,7 +263,7 @@ impl FormatStringParser<'_> {
             self.advance_one().unwrap();
         }
 
-        let width = self.parse_format_width();
+        let width = self.parse_format_width()?;
 
         let first = self.advance_one()?;
         if first == '%' {

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -519,6 +519,30 @@ fn find_printf_octal_escape_before_multibyte_char() {
         .stdout_only("\0€\n");
 }
 
+#[test]
+fn find_printf_width_too_large() {
+    ucmd()
+        .args(&[
+            "./test_data/simple",
+            "-maxdepth",
+            "0",
+            "-printf",
+            "%70000s\\n",
+        ])
+        .fails()
+        .stderr_contains("find: Format width too large");
+    ucmd()
+        .args(&[
+            "./test_data/simple",
+            "-maxdepth",
+            "0",
+            "-printf",
+            "%99999999999999999999s\\n",
+        ])
+        .fails()
+        .stderr_contains("find: Invalid format width");
+}
+
 #[cfg(unix)]
 #[test]
 fn find_perm() {


### PR DESCRIPTION
Fixes #732
Fixes #693

A `-printf` field width could panic two ways:

- a width above `u16::MAX` (65535) reached `core::fmt`'s `{:>width$}`, which caps the width argument at `u16::MAX` and panics with "Formatting argument out of range" (#693);
- a width above `usize::MAX` was `.unwrap()`-ed after a failed parse (#732).

```console
$ mkdir d; touch d/a
$ find d -printf '%70000s\n'                  # #693
thread 'main' panicked at src/find/matchers/printf.rs:611:37:
Formatting argument out of range

$ find d -printf '%99999999999999999999s\n'   # #732
thread 'main' panicked at src/find/matchers/printf.rs:223:45:
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: PosOverflow }
```

`parse_format_width` is now fallible and rejects both an unparseable (too-large-for-`usize`) width and any width above `u16::MAX`, with a graceful error (exit 1) instead of aborting. Widths up to 65535 still pad as before.

Note on the threshold: this rejects any width above `u16::MAX` (65535), which is **below** GNU's `-printf` width ceiling (glibc's `printf` pads up to near `INT_MAX` = 2147483647 and errors with `EOVERFLOW` above it). 65535 is the limit of Rust's `core::fmt` width argument, so it's where padding can be done without panicking; widths in `65536..INT_MAX` that GNU would pad are rejected here rather than emitting up to gigabytes of padding. This keeps the fix minimal and panic-free — a future change could pad those manually to fully match GNU.

Added an integration test (`find_printf_width_too_large`).
