### PR TITLE
xargs: do not panic on empty input in replace mode

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -1159,7 +1159,7 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
             options.exit_if_pass_char_limit,
             options.max_args,
             options.max_lines,
-            options.no_run_if_empty,
+            options.no_run_if_empty || options.replace.is_some(),
         ),
     )?;
     Ok(result)

--- a/tests/test_xargs.rs
+++ b/tests/test_xargs.rs
@@ -74,6 +74,15 @@ fn xargs_if_empty() {
 }
 
 #[test]
+fn xargs_replace_empty_input() {
+    ucmd()
+        .args(&["-I", "{}", "echo", "hello", "{}"])
+        .succeeds()
+        .no_output();
+    ucmd().args(&["-i", "echo", "{}"]).succeeds().no_output();
+}
+
+#[test]
 fn xargs_max_args() {
     ucmd()
         .args(&["-n2"])


### PR DESCRIPTION
Fixes #735

`xargs -I {}` (and `-i`, `--replace`) panicked on empty input:

```console
$ printf '' | xargs -I {} echo hello {}
thread 'main' panicked at src/xargs/mod.rs:429:46:
index out of bounds: the len is 0 but the index is 0
$ echo $?
101
```

In replace mode `xargs` runs the command once per input item, so with empty input it should run nothing. Instead the final builder was still executed and `CommandBuilder::execute` indexed `extra_args[0]`, which is empty when no items were read.

This treats replace mode as implying `--no-run-if-empty` (as GNU does), so empty input runs nothing and exits 0:

```console
$ printf '' | xargs -I {} echo hello {} ; echo $?
0
```

Non-empty replace input still runs per item, and non-replace / `-r` behavior is unchanged. Added a regression test (`xargs_replace_empty_input`).
