### PR TITLE
find: avoid panic on -printf width above u16::MAX

### DIFF
--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -601,13 +601,13 @@ impl Printf {
                 } => match format_directive(file_info, directive) {
                     Ok(content) => {
                         if let Some(width) = width {
+                            // Pad manually rather than relying on the format
+                            // machinery's `{:width$}` support, whose dynamic
+                            // width is capped at `u16::MAX` and panics above it.
+                            let pad = " ".repeat(width.saturating_sub(content.chars().count()));
                             match justify {
-                                Justify::Left => {
-                                    write!(out, "{content:<width$}").unwrap();
-                                }
-                                Justify::Right => {
-                                    write!(out, "{content:>width$}").unwrap();
-                                }
+                                Justify::Left => write!(out, "{content}{pad}").unwrap(),
+                                Justify::Right => write!(out, "{pad}{content}").unwrap(),
                             }
                         } else {
                             write!(out, "{content}").unwrap();
@@ -847,6 +847,20 @@ mod tests {
         let matcher = Printf::new("%f,%7f,%-7f", None).unwrap();
         assert!(matcher.matches(&file_info, &mut deps.new_matcher_io()));
         assert_eq!("abbbc,  abbbc,abbbc  ", deps.get_output_as_string());
+    }
+
+    #[test]
+    fn test_printf_large_width_does_not_panic() {
+        let file_info = get_dir_entry_for("test_data/simple", "abbbc");
+        let deps = FakeDependencies::new();
+
+        // Widths above u16::MAX used to panic in the format machinery.
+        let matcher = Printf::new("%100000f", None).unwrap();
+        assert!(matcher.matches(&file_info, &mut deps.new_matcher_io()));
+        let output = deps.get_output_as_string();
+        assert_eq!(output.len(), 100000);
+        assert!(output.ends_with("abbbc"));
+        assert_eq!(output.trim_start(), "abbbc");
     }
 
     #[test]

--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -858,7 +858,7 @@ mod tests {
         let matcher = Printf::new("%100000f", None).unwrap();
         assert!(matcher.matches(&file_info, &mut deps.new_matcher_io()));
         let output = deps.get_output_as_string();
-        assert_eq!(output.len(), 100000);
+        assert_eq!(output.len(), 100_000);
         assert!(output.ends_with("abbbc"));
         assert_eq!(output.trim_start(), "abbbc");
     }


### PR DESCRIPTION
`find -printf "%111111c"` (or any directive with a width above 65535) panics with `Formatting argument out of range`, as reported in #693. The width is passed straight into `{content:>width$}`, but the formatting machinery caps a runtime width at `u16::MAX` and panics for anything larger.

This pads the field by hand with `str::repeat` instead, so the output matches the requested width for any value and large widths no longer crash. Added a regression test that exercises a width of 100000.

Closes #693
