### PR TITLE
clippy: fix warnings

### DIFF
--- a/src/find/matchers/exec.rs
+++ b/src/find/matchers/exec.rs
@@ -227,7 +227,7 @@ impl Matcher for MultiExecMatcher {
                 writeln!(
                     &mut stderr(),
                     "Cannot fit a single argument {}: {}",
-                    &path_to_file.to_string_lossy(),
+                    path_to_file.to_string_lossy(),
                     e
                 )
                 .unwrap();

--- a/src/find/matchers/glob.rs
+++ b/src/find/matchers/glob.rs
@@ -125,18 +125,15 @@ fn glob_to_regex(pattern: &str) -> Option<String> {
             '?' => regex.push('.'),
             '*' => regex.push_str(".*"),
             '\\' => {
-                if let Some(ch) = chars.next() {
-                    regex_push_literal(&mut regex, ch);
-                } else {
-                    // https://pubs.opengroup.org/onlinepubs/9699919799/functions/fnmatch.html
-                    //
-                    //     If pattern ends with an unescaped <backslash>, fnmatch() shall return a
-                    //     non-zero value (indicating either no match or an error).
-                    //
-                    // Most implementations return FNM_NOMATCH in this case, so create a pattern that
-                    // never matches.
-                    return None;
-                }
+                // https://pubs.opengroup.org/onlinepubs/9699919799/functions/fnmatch.html
+                //
+                //     If pattern ends with an unescaped <backslash>, fnmatch() shall return a
+                //     non-zero value (indicating either no match or an error).
+                //
+                // Most implementations return FNM_NOMATCH in this case, so create a pattern that
+                // never matches.
+                let ch = chars.next()?;
+                regex_push_literal(&mut regex, ch);
             }
             '[' => {
                 if let Some((expr, rest)) = extract_bracket_expr(chars.as_str()) {

--- a/src/locate/mod.rs
+++ b/src/locate/mod.rs
@@ -547,7 +547,7 @@ fn match_entry(entry: &CStr, config: &Config, patterns: &Patterns) -> bool {
             path.as_encoded_bytes()
                 .iter()
                 .copied()
-                .chain([b'\0'])
+                .chain(*b"\0")
                 .collect(),
         ) else {
             // a file name can't contain an interior nul byte, so this only fails on

--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -1448,7 +1448,10 @@ mod tests {
         let mut wrapper = EofArgumentReader::new(Box::new(reader), &filter);
         assert_eq!(wrapper.next().unwrap().unwrap(), make_arg_soft("abc"));
         assert_eq!(wrapper.next().unwrap().unwrap(), make_arg_soft("deF"));
-        assert!(wrapper.next().err().unwrap().kind() == io::ErrorKind::BrokenPipe);
+        assert_eq!(
+            wrapper.next().err().unwrap().kind(),
+            io::ErrorKind::BrokenPipe
+        );
         assert_eq!(wrapper.next().unwrap().unwrap(), make_arg_soft("ghi"));
         assert_eq!(wrapper.next().unwrap(), None);
         assert_eq!(wrapper.next().unwrap(), None);

--- a/tests/exec_unit_tests.rs
+++ b/tests/exec_unit_tests.rs
@@ -357,7 +357,7 @@ fn multi_set_exit_code_if_executable_fails() {
     assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));
     let mut matcher_io = deps.new_matcher_io();
     matcher.finished_dir(Path::new("test_data/simple"), &mut matcher_io);
-    assert!(matcher_io.exit_code() == 1);
+    assert_eq!(matcher_io.exit_code(), 1);
 
     let mut f = File::open(temp_dir.path().join("1.txt")).expect("Failed to open output file");
     let mut s = String::new();
@@ -380,7 +380,7 @@ fn multi_set_exit_code_if_command_fails() {
     assert!(matcher.matches(&abbbc, &mut deps.new_matcher_io()));
     let mut matcher_io = deps.new_matcher_io();
     matcher.finished_dir(Path::new("test_data/simple"), &mut matcher_io);
-    assert!(matcher_io.exit_code() == 1);
+    assert_eq!(matcher_io.exit_code(), 1);
 }
 
 // -ok / -okdir tests


### PR DESCRIPTION
This PR fixes clippy warnings from the [byte_char_slices](https://rust-lang.github.io/rust-clippy/master/index.html#byte_char_slices), [useless_borrows_in_formatting](https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting), [question_mark](https://rust-lang.github.io/rust-clippy/master/index.html#question_mark), and [manual_assert_eq](https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert_eq) lints that show up with Rust `1.97`.