### PR TITLE
find: -printf: fix %A+/%C+/%T+ fractional seconds to match GNU

### DIFF
--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -52,7 +52,7 @@ impl TimeFormat {
             }
             Self::Strftime(format) => {
                 // Handle a special case
-                let custom_format = format.replace("%+", "%Y-%m-%d+%H:%M:%S%.f0");
+                let custom_format = format.replace("%+", "%Y-%m-%d+%H:%M:%S.%f0");
                 DateTime::<Local>::from(time)
                     .format(&custom_format)
                     .to_string()


### PR DESCRIPTION
`-printf` `%A+`/`%C+`/`%T+` diverged from GNU on low-precision timestamps. The `%+` format expanded to `…%S%.f0`, using chrono's `%.f`, which trims trailing zeros and omits the fraction entirely when it is zero. GNU always writes a fixed-width fraction (`snprintf(".%09ld0", tv_nsec)` in `find/print.c`).

Before:

```console
$ touch -d @1700000000 a          # whole second, ns = 0
$ find a -printf '%A+\n'
2023-11-14+22:13:200              # missing ".NNNNNNNNN"
$ /usr/bin/find a -printf '%A+\n'
2023-11-14+22:13:20.0000000000
```

After — matches GNU byte-for-byte across ns = 0 / microsecond / full precision:

```console
$ find a -printf '%A+\n'
2023-11-14+22:13:20.0000000000
```

The fix uses `.%f` (literal dot + fixed 9-digit `%f`), like the `%S` and ctime paths already do. As a side effect it makes the existing `find_printf` test's `%A+` assertion deterministic (always `.NNNNNNNNN0`), which removes the intermittent Windows CI failure seen on that test.
