### PR TITLE
find: avoid "find: find:" in two error messages

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -953,7 +953,7 @@ fn build_matcher_tree(
                         }
                         #[cfg(target_os = "linux")]
                         if x_option == "B" {
-                            return Err(From::from("find: This system does not provide a way to find the birth time of a file."));
+                            return Err(From::from("This system does not provide a way to find the birth time of a file."));
                         }
                         if y_option == "t" {
                             let time = args[i + 1];
@@ -961,7 +961,7 @@ fn build_matcher_tree(
                             // Convert args to unix timestamps. (expressed in numeric types)
                             let Some(comparable_time) = parse_date_str_to_timestamps(time) else {
                                 return Err(From::from(format!(
-                                    "find: I cannot figure out how to interpret ‘{}’ as a date or time",
+                                    "I cannot figure out how to interpret ‘{}’ as a date or time",
                                     args[i + 1]
                                 )));
                             };

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -819,7 +819,19 @@ fn find_newer_xy() {
                 .succeeds()
                 .no_stderr();
         }
+
+        ucmd().args(&[".", arg, "invalid"]).fails().stderr_only(
+            "find: I cannot figure out how to interpret ‘invalid’ as a date or time\n",
+        );
     }
+
+    #[cfg(target_os = "linux")]
+    ucmd()
+        .args(&[".", "-newerBt", "jan 01, 2000"])
+        .fails()
+        .stderr_only(
+            "find: This system does not provide a way to find the birth time of a file.\n",
+        );
 }
 
 #[test]


### PR DESCRIPTION
While reviewing https://github.com/uutils/findutils/pull/762 I noticed that two error messages start with "find: find:". This PR fixes them.