### PR TITLE
find: reject invalid -newerXY predicates like GNU

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -399,6 +399,10 @@ fn parse_date_str_to_timestamps(date_str: &str) -> Option<i64> {
 /// X and Y are constrained to a/B/c/m and t.
 /// such as: "-neweraB" -> Some(a, B) "-neweraD" -> None
 ///
+/// The whole argument must match. A trailing suffix after a valid
+/// -newerXY form (for example -neweraBcmty) is not accepted; GNU find
+/// reports those as unknown predicates.
+///
 /// Additionally, there is support for the -anewer and -cnewer short arguments. as follows:
 /// 1. -anewer is equivalent to -neweram
 /// 2. -cnewer is equivalent to -newercm
@@ -421,7 +425,9 @@ fn parse_str_to_newer_args(input: &str) -> Option<(String, String)> {
         return Some(("c".to_string(), "m".to_string()));
     }
 
-    let re = Regex::new(r"-newer([aBcm])([aBcmt])").unwrap();
+    // Require a full-token match so invalid longer forms like
+    // -neweraBcmty are not treated as the valid -neweraB prefix (#782).
+    let re = Regex::new(r"^-newer([aBcm])([aBcmt])$").unwrap();
     if let Some(captures) = re.captures(input) {
         let x = captures.get(1)?.as_str().to_string();
         let y = captures.get(2)?.as_str().to_string();
@@ -976,7 +982,10 @@ fn build_matcher_tree(
                             )
                         }
                     }
-                    None => return Err(From::from(format!("Unrecognized flag: '{}'", args[i]))),
+                    // Match GNU find wording for unknown predicates.
+                    None => {
+                        return Err(From::from(format!("unknown predicate `{}'", args[i])));
+                    }
                 }
             }
         };
@@ -1874,6 +1883,31 @@ mod tests {
                 let arg = parse_str_to_newer_args(&format!("-newer{x}{y}").to_string()).unwrap();
                 assert_eq!(eq, arg);
             }
+        }
+
+        // Trailing junk after a valid -newerXY form must not match.
+        // GNU find reports these as unknown predicates (issue #782).
+        assert!(parse_str_to_newer_args("-neweraBcmty").is_none());
+        assert!(parse_str_to_newer_args("-newermmEXTRA").is_none());
+        assert!(parse_str_to_newer_args("-neweramtz").is_none());
+        assert!(parse_str_to_newer_args("-newera").is_none());
+    }
+
+    #[test]
+    fn build_top_level_matcher_rejects_invalid_newer_predicate() {
+        let mut config = Config::default();
+        match build_top_level_matcher(&["-neweraBcmty"], &mut config) {
+            Ok(_) => panic!("invalid -newerXY suffix must be rejected"),
+            Err(err) => assert_eq!(err.to_string(), "unknown predicate `-neweraBcmty'"),
+        }
+    }
+
+    #[test]
+    fn build_top_level_matcher_rejects_unknown_predicate() {
+        let mut config = Config::default();
+        match build_top_level_matcher(&["-notarealpredicate"], &mut config) {
+            Ok(_) => panic!("unknown predicates must be rejected"),
+            Err(err) => assert_eq!(err.to_string(), "unknown predicate `-notarealpredicate'"),
         }
     }
 

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -548,7 +548,7 @@ mod tests {
         //
         let result = super::parse_args(&["-asdadsafsfsadcs"]);
         if let Err(e) = result {
-            assert_eq!(e.to_string(), "Unrecognized flag: '-asdadsafsfsadcs'");
+            assert_eq!(e.to_string(), "unknown predicate `-asdadsafsfsadcs'");
         } else {
             panic!("parse_args should have returned an error");
         }
@@ -1107,12 +1107,15 @@ mod tests {
 
                 assert_eq!(rc, 0);
 
-                let arg = &format!("-follow -newer{x}{y}").to_string();
+                // -follow and -newerXY are separate argv tokens; they must not
+                // be glued into one string or the whole token is an unknown
+                // predicate once -newerXY matching is exact.
                 let deps = FakeDependencies::new();
                 let rc = find_main(
                     &[
                         "find",
                         "./test_data/simple/subdir",
+                        "-follow",
                         arg,
                         "./test_data/simple/subdir/ABBBC",
                     ],

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -83,6 +83,23 @@ fn multiple_matcher_success() {
 }
 
 #[test]
+fn invalid_newerxy_predicate_is_rejected() {
+    // GNU find rejects over-long / invalid -newerXY tokens instead of matching a
+    // valid prefix (issue #782: -neweraBcmty was accepted as -neweraB).
+    ucmd()
+        .args(&["-neweraBcmty", "."])
+        .fails()
+        .stderr_contains("unknown predicate `-neweraBcmty'")
+        .no_stdout();
+
+    ucmd()
+        .args(&["-newermmEXTRA", "."])
+        .fails()
+        .stderr_contains("unknown predicate `-newermmEXTRA'")
+        .no_stdout();
+}
+
+#[test]
 fn multiple_matcher_failure() {
     ucmd()
         .args(&["-type", "fd", "-name", "abbb"])


### PR DESCRIPTION
## Summary

`find` accepted invalid predicates such as `-neweraBcmty` because the `-newerXY` parser matched a valid prefix instead of the whole argument. GNU find reports those as unknown predicates.

This change:

- anchors `-newerXY` matching so only exact `X∈{a,B,c,m}` / `Y∈{a,B,c,m,t}` forms parse
- reports unknown predicates with GNU-style wording: `unknown predicate \`…'` (as in the issue sample)
- adds unit + integration coverage for the issue #782 cases
- fixes a pre-existing unit test that incorrectly glued `-follow -newerXY` into one argv token (that only worked while the regex was unanchored)

Note: open PR #724 only rewords the unknown-predicate message for ordinary unrecognized args. This PR also fixes the real #782 root cause (prefix match on `-newerXY`) and uses the GNU backtick/apostrophe quote shape from the issue.

## Test plan

- [x] `cargo test --lib` (227 passed)
- [x] `cargo test --test test_find invalid_newerxy_predicate_is_rejected`
- [x] Integration harness covers `find -neweraBcmty .` failing with `unknown predicate \`-neweraBcmty'`

Fixes #782
