### PR TITLE
xargs: cap the default command line size at 128 KiB

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -191,7 +191,18 @@ impl MaxCharsCommandSizeLimiter {
             .map(|(var, value)| count_osstr_chars_for_exec(var) + count_osstr_chars_for_exec(value))
             .sum();
 
-        Self::new(arg_max - ARG_HEADROOM - env_size)
+        Self::new(arg_max.saturating_sub(ARG_HEADROOM + env_size))
+    }
+
+    /// The limiter used when no explicit -s was given. Like GNU xargs, use at
+    /// most 128 KiB per command line by default: sizing command lines all the
+    /// way up to ARG_MAX would make execvp() fail with E2BIG, because the
+    /// kernel additionally charges the argv/envp pointers (since Linux commit
+    /// 98da7d08850f) against the limit, which are not part of the character
+    /// count. An explicit -s can still go beyond this, up to the system limit.
+    fn new_default(env: &HashMap<OsString, OsString>) -> Self {
+        const DEFAULT_MAX_CHARS: usize = 128 * 1024;
+        Self::new(Self::new_system(env).max_chars.min(DEFAULT_MAX_CHARS))
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -1125,6 +1136,8 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
     }
     if let Some(max_chars) = options.max_chars {
         limiters.add(MaxCharsCommandSizeLimiter::new(max_chars));
+    } else {
+        limiters.add(MaxCharsCommandSizeLimiter::new_default(&env));
     }
     limiters.add(MaxCharsCommandSizeLimiter::new_system(&env));
 
@@ -1280,7 +1293,10 @@ mod tests {
 
     #[test]
     fn test_chars_limiter() {
-        let mut limiter = MaxCharsCommandSizeLimiter::new(6);
+        // Room for exactly "abc" and "a", including terminators and pointers.
+        let max_chars = count_osstr_chars_for_exec(OsStr::new("abc"))
+            + count_osstr_chars_for_exec(OsStr::new("a"));
+        let mut limiter = MaxCharsCommandSizeLimiter::new(max_chars);
         assert!(limiter
             .try_arg(make_arg_hard("abc"), empty_cursor())
             .is_ok());
@@ -1291,13 +1307,24 @@ mod tests {
     }
 
     #[test]
+    fn test_default_chars_limiter_caps_system_limit() {
+        let env = HashMap::new();
+        let system = MaxCharsCommandSizeLimiter::new_system(&env);
+        let default = MaxCharsCommandSizeLimiter::new_default(&env);
+        // The default never exceeds 128 KiB nor what the system allows.
+        assert!(default.max_chars <= 128 * 1024);
+        assert!(default.max_chars <= system.max_chars);
+    }
+
+    #[test]
     fn test_chars_limiter_asks_cursor() {
         let mut rejects: [Box<dyn CommandSizeLimiter>; 1] = [Box::new(AlwaysRejectLimiter)];
         let reject_cursor = LimiterCursor {
             limiters: &mut rejects,
         };
 
-        let mut limiter = MaxCharsCommandSizeLimiter::new(5);
+        let mut limiter =
+            MaxCharsCommandSizeLimiter::new(count_osstr_chars_for_exec(OsStr::new("abc")));
         assert!(limiter
             .try_arg(make_arg_hard("abc"), reject_cursor)
             .is_err());

--- a/tests/test_xargs.rs
+++ b/tests/test_xargs.rs
@@ -195,6 +195,46 @@ fn xargs_exit_on_large() {
 }
 
 #[test]
+#[cfg(unix)]
+fn xargs_batches_large_input_below_system_limit() {
+    // Arguments totalling more than ARG_MAX must be split into several
+    // command invocations instead of failing with E2BIG.
+    let arg_count = 60_000;
+    let input = (0..arg_count)
+        .map(|i| format!("/some/path/to/a/file/with/a/long/name-{i:06}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let result = ucmd().arg("echo").pipe_in(input).succeeds();
+    assert_eq!(
+        arg_count,
+        result.stdout_str().split_ascii_whitespace().count()
+    );
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn xargs_explicit_size_can_exceed_default_cap() {
+    // An explicit -s larger than the 128 KiB default cap must be honored:
+    // ~200 KiB of arguments fit into a single invocation with -s 300000.
+    let arg_count = 4_000;
+    let input = (0..arg_count)
+        .map(|i| format!("/quite/a/long/path/segment/for/padding-{i:06}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let result = ucmd()
+        .args(&["-s", "300000", "echo"])
+        .pipe_in(input)
+        .succeeds();
+    assert_eq!(1, result.stdout_str().lines().count());
+    assert_eq!(
+        arg_count,
+        result.stdout_str().split_ascii_whitespace().count()
+    );
+}
+
+#[test]
 fn xargs_exec() {
     let result = ucmd()
         .args(&[


### PR DESCRIPTION
Sizing command lines all the way up to ARG_MAX made execvp() fail with E2BIG: the kernel also charges the argv/envp pointer arrays against the limit, which the character count does not account for. Follow GNU xargs and use at most 128 KiB per command line by default, and use a saturating subtraction so a tiny ARG_MAX cannot underflow.

The cap only applies when no explicit -s was given: like GNU, an explicit -s may still raise the limit up to the system maximum.