### PR TITLE
find: print a fixed-width fraction for -printf %T+

### DIFF
--- a/src/find/matchers/printf.rs
+++ b/src/find/matchers/printf.rs
@@ -52,7 +52,10 @@ impl TimeFormat {
             }
             Self::Strftime(format) => {
                 // Handle a special case
-                let custom_format = format.replace("%+", "%Y-%m-%d+%H:%M:%S%.f0");
+                // GNU prints a fixed-width fraction: dot, nine nanosecond
+                // digits, plus a trailing literal zero. chrono's `%.f` would
+                // drop the fraction (and the dot) entirely when it is zero.
+                let custom_format = format.replace("%+", "%Y-%m-%d+%H:%M:%S.%f0");
                 DateTime::<Local>::from(time)
                     .format(&custom_format)
                     .to_string()
@@ -1087,6 +1090,42 @@ mod tests {
             ),
             deps.get_output_as_string()
         );
+    }
+
+    #[test]
+    fn test_printf_time_plus_format() {
+        let temp_dir = Builder::new().prefix("example").tempdir().unwrap();
+        let temp_dir_path = temp_dir.path().to_string_lossy();
+        let new_file_name = "newFile";
+        let file_path = temp_dir.path().join(new_file_name);
+        File::create(&file_path).expect("create temp file");
+
+        // GNU findutils always prints a dot and ten fractional digits, even
+        // for timestamps that fall on a whole second.
+        for (nanos, expected_time) in [
+            (0, "2000-01-15+09:30:21.0000000000"),
+            (500_000_000, "2000-01-15+09:30:21.5000000000"),
+        ] {
+            let mtime = chrono::Local
+                .with_ymd_and_hms(2000, 1, 15, 9, 30, 21)
+                .unwrap()
+                + Duration::nanoseconds(nanos);
+            filetime::set_file_mtime(
+                &file_path,
+                filetime::FileTime::from_unix_time(
+                    mtime.timestamp(),
+                    mtime.timestamp_subsec_nanos(),
+                ),
+            )
+            .expect("set temp file mtime");
+
+            let file_info = get_dir_entry_for(&temp_dir_path, new_file_name);
+            let deps = FakeDependencies::new();
+
+            let matcher = Printf::new("%T+", None).unwrap();
+            assert!(matcher.matches(&file_info, &mut deps.new_matcher_io()));
+            assert_eq!(expected_time, deps.get_output_as_string());
+        }
     }
 
     #[test]

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -511,6 +511,34 @@ fn find_printf() {
 }
 
 #[test]
+#[cfg(unix)] // %T+ prints local time; TZ only reliably selects it on unix
+fn find_printf_time_plus_fixed_width_fraction() {
+    let temp_dir = Builder::new().prefix("find_time_plus_").tempdir().unwrap();
+    let file_path = temp_dir.path().join("stamped");
+    File::create(&file_path).expect("create test file");
+
+    // The fraction must always be a dot followed by ten digits, even when
+    // the timestamp falls on a whole second.
+    for (nanos, expected) in [
+        (0, "2013-06-20+11:22:33.0000000000\n"),
+        (250_000_000, "2013-06-20+11:22:33.2500000000\n"),
+    ] {
+        filetime::set_file_mtime(
+            &file_path,
+            filetime::FileTime::from_unix_time(1_371_727_353, nanos),
+        )
+        .expect("set test file mtime");
+
+        ucmd()
+            .env("TZ", "UTC0")
+            .arg(&file_path)
+            .args(&["-printf", "%T+\n"])
+            .succeeds()
+            .stdout_only(expected);
+    }
+}
+
+#[test]
 fn find_printf_octal_escape_before_multibyte_char() {
     ucmd()
         .args(&["./test_data/simple", "-maxdepth", "0", "-printf", "\\0€\\n"])


### PR DESCRIPTION
chrono's %.f drops the fraction (and the leading dot) entirely when the sub-second part is zero, while GNU find always prints a dot followed by ten fractional digits. Use an explicit .%f0 so whole-second timestamps format the same way as GNU.

Causes a bug with lintian