### PR TITLE
find: visit nothing when -mindepth exceeds -maxdepth

### DIFF
--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -211,6 +211,16 @@ fn process_dir(
     matcher: &dyn matchers::Matcher,
     quit: &mut bool,
 ) -> i32 {
+    // No depth can satisfy both bounds when -mindepth exceeds -maxdepth, so GNU
+    // find visits nothing at all. walkdir clamps min_depth down to max_depth
+    // instead (see `WalkDir::min_depth`), which would make us descend anyway, so
+    // handle the empty traversal ourselves.
+    if config.min_depth > config.max_depth {
+        let mut matcher_io = matchers::MatcherIO::new(deps);
+        matcher.finished(&mut matcher_io);
+        return matcher_io.exit_code();
+    }
+
     let mut walkdir = WalkDir::new(dir)
         .contents_first(config.depth_first)
         .max_depth(config.max_depth)
@@ -814,6 +824,67 @@ mod tests {
                  ./test_data/depth/1/2/f2\n"
             )
         );
+    }
+
+    #[test]
+    fn find_mindepth_greater_than_maxdepth() {
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-mindepth",
+                "2",
+                "-maxdepth",
+                "1",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
+    }
+
+    #[test]
+    fn find_maxdepth_less_than_mindepth_reversed_order() {
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-maxdepth",
+                "1",
+                "-mindepth",
+                "2",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
+    }
+
+    #[test]
+    fn find_mindepth_greater_than_maxdepth_depth_first() {
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-mindepth",
+                "2",
+                "-maxdepth",
+                "1",
+                "-depth",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
     }
 
     #[test]

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -899,67 +899,6 @@ mod tests {
     }
 
     #[test]
-    fn find_mindepth_greater_than_maxdepth() {
-        let deps = FakeDependencies::new();
-        let rc = find_main(
-            &[
-                "find",
-                &fix_up_slashes("./test_data/depth"),
-                "-sorted",
-                "-mindepth",
-                "2",
-                "-maxdepth",
-                "1",
-            ],
-            &deps,
-        );
-
-        assert_eq!(rc, 0);
-        assert_eq!(deps.get_output_as_string(), "");
-    }
-
-    #[test]
-    fn find_maxdepth_less_than_mindepth_reversed_order() {
-        let deps = FakeDependencies::new();
-        let rc = find_main(
-            &[
-                "find",
-                &fix_up_slashes("./test_data/depth"),
-                "-sorted",
-                "-maxdepth",
-                "1",
-                "-mindepth",
-                "2",
-            ],
-            &deps,
-        );
-
-        assert_eq!(rc, 0);
-        assert_eq!(deps.get_output_as_string(), "");
-    }
-
-    #[test]
-    fn find_mindepth_greater_than_maxdepth_depth_first() {
-        let deps = FakeDependencies::new();
-        let rc = find_main(
-            &[
-                "find",
-                &fix_up_slashes("./test_data/depth"),
-                "-sorted",
-                "-mindepth",
-                "2",
-                "-maxdepth",
-                "1",
-                "-depth",
-            ],
-            &deps,
-        );
-
-        assert_eq!(rc, 0);
-        assert_eq!(deps.get_output_as_string(), "");
-    }
-
-    #[test]
     fn find_newer() {
         // create a temp directory and file that are newer than the static
         // files in the source tree.

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -827,67 +827,6 @@ mod tests {
     }
 
     #[test]
-    fn find_mindepth_greater_than_maxdepth() {
-        let deps = FakeDependencies::new();
-        let rc = find_main(
-            &[
-                "find",
-                &fix_up_slashes("./test_data/depth"),
-                "-sorted",
-                "-mindepth",
-                "2",
-                "-maxdepth",
-                "1",
-            ],
-            &deps,
-        );
-
-        assert_eq!(rc, 0);
-        assert_eq!(deps.get_output_as_string(), "");
-    }
-
-    #[test]
-    fn find_maxdepth_less_than_mindepth_reversed_order() {
-        let deps = FakeDependencies::new();
-        let rc = find_main(
-            &[
-                "find",
-                &fix_up_slashes("./test_data/depth"),
-                "-sorted",
-                "-maxdepth",
-                "1",
-                "-mindepth",
-                "2",
-            ],
-            &deps,
-        );
-
-        assert_eq!(rc, 0);
-        assert_eq!(deps.get_output_as_string(), "");
-    }
-
-    #[test]
-    fn find_mindepth_greater_than_maxdepth_depth_first() {
-        let deps = FakeDependencies::new();
-        let rc = find_main(
-            &[
-                "find",
-                &fix_up_slashes("./test_data/depth"),
-                "-sorted",
-                "-mindepth",
-                "2",
-                "-maxdepth",
-                "1",
-                "-depth",
-            ],
-            &deps,
-        );
-
-        assert_eq!(rc, 0);
-        assert_eq!(deps.get_output_as_string(), "");
-    }
-
-    #[test]
     fn find_newer() {
         // create a temp directory and file that are newer than the static
         // files in the source tree.

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -276,6 +276,16 @@ fn process_dir(
     matcher: &dyn matchers::Matcher,
     quit: &mut bool,
 ) -> i32 {
+    // No depth can satisfy both bounds when -mindepth exceeds -maxdepth, so GNU
+    // find visits nothing at all. walkdir clamps min_depth down to max_depth
+    // instead (see `WalkDir::min_depth`), which would make us descend anyway, so
+    // handle the empty traversal ourselves.
+    if config.min_depth > config.max_depth {
+        let mut matcher_io = matchers::MatcherIO::new(deps);
+        matcher.finished(&mut matcher_io);
+        return matcher_io.exit_code();
+    }
+
     let mut walkdir = WalkDir::new(dir)
         .contents_first(config.depth_first)
         .max_depth(config.max_depth)
@@ -886,6 +896,67 @@ mod tests {
                  ./test_data/depth/1/2/f2\n"
             )
         );
+    }
+
+    #[test]
+    fn find_mindepth_greater_than_maxdepth() {
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-mindepth",
+                "2",
+                "-maxdepth",
+                "1",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
+    }
+
+    #[test]
+    fn find_maxdepth_less_than_mindepth_reversed_order() {
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-maxdepth",
+                "1",
+                "-mindepth",
+                "2",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
+    }
+
+    #[test]
+    fn find_mindepth_greater_than_maxdepth_depth_first() {
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-mindepth",
+                "2",
+                "-maxdepth",
+                "1",
+                "-depth",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
     }
 
     #[test]

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -1297,6 +1297,40 @@ fn find_ls_unmapped_owner_renders_numeric_id() {
 }
 
 #[test]
+fn find_mindepth_greater_than_maxdepth() {
+    ucmd()
+        .args(&["./test_data/depth", "-mindepth", "2", "-maxdepth", "1"])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
+fn find_maxdepth_less_than_mindepth_reversed_order() {
+    ucmd()
+        .args(&["./test_data/depth", "-maxdepth", "1", "-mindepth", "2"])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
+fn find_mindepth_greater_than_maxdepth_depth_first() {
+    ucmd()
+        .args(&[
+            "./test_data/depth",
+            "-mindepth",
+            "2",
+            "-maxdepth",
+            "1",
+            "-depth",
+        ])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
 #[cfg(unix)]
 fn find_slashes() {
     ucmd()

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -1131,6 +1131,40 @@ fn find_ls_unmapped_owner_renders_numeric_id() {
 }
 
 #[test]
+fn find_mindepth_greater_than_maxdepth() {
+    ucmd()
+        .args(&["./test_data/depth", "-mindepth", "2", "-maxdepth", "1"])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
+fn find_maxdepth_less_than_mindepth_reversed_order() {
+    ucmd()
+        .args(&["./test_data/depth", "-maxdepth", "1", "-mindepth", "2"])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
+fn find_mindepth_greater_than_maxdepth_depth_first() {
+    ucmd()
+        .args(&[
+            "./test_data/depth",
+            "-mindepth",
+            "2",
+            "-maxdepth",
+            "1",
+            "-depth",
+        ])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
 #[cfg(unix)]
 fn find_slashes() {
     ucmd()


### PR DESCRIPTION
Fixes #778

`find -mindepth 2 -maxdepth 1` printed every entry at depth 1 instead of
printing nothing.

### Cause

`process_dir` forwards both bounds to `walkdir`:

```rust
.max_depth(config.max_depth)
.min_depth(config.min_depth)
```

`WalkDir::min_depth` clamps `min_depth` down to `max_depth` rather than
producing an empty walk (walkdir 2.5.0, `src/lib.rs:310-316`). So
`-mindepth 2 -maxdepth 1` became `-mindepth 1 -maxdepth 1` and the walk
descended anyway. Argument order does not matter: `max_depth` applies the
same clamp.

### Fix

No depth can satisfy both bounds when `-mindepth` exceeds `-maxdepth`, so
skip the traversal explicitly. The end-of-walk handling is kept, so the
utility behaves exactly as it does for a walk that yields no entries -
verified for `-exec ... +` (runs nothing) and `-fprint` (creates an empty
file).

### Tests

Three unit tests added next to the existing depth tests, covering both
argument orders and `-depth`. All three fail without the fix.

Behaviour checked against GNU findutils 4.11.0 as a black box (no GNU
sources consulted or referenced):

| invocation | uu (before) | uu (after) | GNU |
|---|---|---|---|
| `-mindepth 2 -maxdepth 1` | depth-1 entries | empty, rc 0 | empty, rc 0 |
| `-maxdepth 1 -mindepth 2` | depth-1 entries | empty, rc 0 | empty, rc 0 |
| `-mindepth 5 -maxdepth 1` | depth-1 entries | empty, rc 0 | empty, rc 0 |
| `-mindepth 1 -maxdepth 0` | depth-0 entry | empty, rc 0 | empty, rc 0 |
| `-mindepth 1 -maxdepth 1` (control) | depth-1 entries | unchanged | same |

`cargo test`: 233 lib + 129 integration tests pass. `cargo fmt --check`
clean. `cargo clippy --all-targets -- -D warnings` reports nothing new
(the one pre-existing finding in `src/locate/mod.rs` is untouched).