### PR TITLE
xargs: reject quotes spanning input lines

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -626,6 +626,12 @@ where
 
             match (&escape, pending[i]) {
                 (Some(Escape::Quote(quote)), c) if c == *quote => escape = None,
+                (Some(Escape::Quote(q)), b'\n') => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Unterminated quote: {q}"),
+                    ));
+                }
                 (Some(Escape::Quote(_)), c) => result.push(c),
                 (Some(Escape::Slash), c) => {
                     result.push(c);

--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -618,6 +618,12 @@ where
 
             match (&escape, pending[i]) {
                 (Some(Escape::Quote(quote)), c) if c == *quote => escape = None,
+                (Some(Escape::Quote(q)), b'\n') => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Unterminated quote: {q}"),
+                    ));
+                }
                 (Some(Escape::Quote(_)), c) => result.push(c),
                 (Some(Escape::Slash), c) => {
                     result.push(c);

--- a/tests/test_xargs.rs
+++ b/tests/test_xargs.rs
@@ -419,6 +419,25 @@ fn xargs_unterminated_quote() {
 }
 
 #[test]
+fn xargs_quotes_cannot_span_lines() {
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+
+    for quote in ['\'', '"'] {
+        std::fs::write(
+            temp_file.path(),
+            format!("alpha{quote}beta\ngamma{quote}\n"),
+        )
+        .unwrap();
+
+        ucmd()
+            .args(&["-a", &temp_file.path().to_string_lossy()])
+            .fails_with_code(1)
+            .stderr_contains("Error: Unterminated quote:")
+            .no_stdout();
+    }
+}
+
+#[test]
 fn xargs_zero_lines() {
     ucmd()
         .args(&[

--- a/tests/test_xargs.rs
+++ b/tests/test_xargs.rs
@@ -391,6 +391,25 @@ fn xargs_unterminated_quote() {
 }
 
 #[test]
+fn xargs_quotes_cannot_span_lines() {
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+
+    for quote in ['\'', '"'] {
+        std::fs::write(
+            temp_file.path(),
+            format!("alpha{quote}beta\ngamma{quote}\n"),
+        )
+        .unwrap();
+
+        ucmd()
+            .args(&["-a", &temp_file.path().to_string_lossy()])
+            .fails_with_code(1)
+            .stderr_contains("Error: Unterminated quote:")
+            .no_stdout();
+    }
+}
+
+#[test]
 fn xargs_zero_lines() {
     ucmd()
         .args(&[


### PR DESCRIPTION
Fixes #776.

The whitespace-delimited argument reader allowed single and double quotes to span input lines. Quotes opened on one line could be closed on a later line, so malformed input was combined into arguments instead of rejected.

Reject a newline while a quote is open, matching GNU and BSD `xargs` behavior. Add regression coverage for both quote types when reading through `--arg-file`.
