### PR TITLE
find: reject invalid UTF-8 in --files0-from

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -1041,9 +1041,8 @@ fn parse_files0_args(config: &mut Config) -> Result<(), Box<dyn Error>> {
 
     let mut string_segments: Vec<String> = buffer_split
         .iter()
-        .filter_map(|s| std::str::from_utf8(s).ok())
-        .map(std::string::ToString::to_string)
-        .collect();
+        .map(|segment| std::str::from_utf8(segment).map(std::string::ToString::to_string))
+        .collect::<Result<_, _>>()?;
     // empty starting point checker
     if string_segments.iter().any(std::string::String::is_empty) {
         eprintln!("find: invalid zero-length file name");

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -195,6 +195,20 @@ fn files0_file_basic_success() {
 }
 
 #[test]
+fn files0_invalid_utf8_fails() {
+    let temp_dir = Builder::new().prefix("find_files0_").tempdir().unwrap();
+    let path_list = temp_dir.path().join("paths0");
+    fs::write(&path_list, b"\xff\nfile2.txt\n").expect("wrote path list");
+
+    ucmd()
+        .arg("-files0-from")
+        .arg(path_list)
+        .fails()
+        .stderr_contains("invalid utf-8 sequence")
+        .no_stdout();
+}
+
+#[test]
 fn files0_empty_pipe() {
     ucmd()
         .args(&["-files0-from", "-"])


### PR DESCRIPTION
Fixes #781.

`--files0-from` decoded each NUL-separated starting point as UTF-8 and silently discarded segments that were not valid UTF-8. As a result, non-UTF-8 input could produce no traversal and a successful exit status.

Propagate UTF-8 decoding errors instead of silently ignoring invalid starting points.

Add a regression test using the issue's non-UTF-8 input and verify that it fails without producing output.
