### PR TITLE
fix: proper read error for device files with -files0-from

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -62,6 +62,7 @@ use ::regex::Regex;
 use chrono::{DateTime, Datelike, NaiveDateTime, Utc};
 use fs::FileSystemMatcher;
 use ls::Ls;
+#[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
 use std::{
     error::Error,
@@ -1033,18 +1034,26 @@ fn parse_files0_args(config: &mut Config) -> Result<(), Box<dyn Error>> {
             File::open(mode).map_err(|e| format!("cannot open '{}' for reading: {}", mode, e))?;
         file.read_to_end(&mut buffer)?;
 
-        let meta = file
-            .metadata()
-            .map_err(|e| format!("cannot stat '{}': {}", mode, e))?;
-
         // Read the entire file.
         let bytes_read = file.read_to_end(&mut buffer)?;
 
-        if bytes_read == 0
-            && (meta.file_type().is_char_device() || meta.file_type().is_block_device())
-        {
-            let err =
-                std::io::Error::other("File descriptor in bad state");
+        let is_special = {
+            #[cfg(unix)]
+            {
+                let meta = file
+                    .metadata()
+                    .map_err(|e| format!("cannot stat '{}': {}", mode, e))?;
+                let file_type = meta.file_type();
+                file_type.is_char_device() || file_type.is_block_device()
+            }
+            #[cfg(not(unix))]
+            {
+                false
+            }
+        };
+
+        if bytes_read == 0 && is_special {
+            let err = std::io::Error::other("File descriptor in bad state");
             return Err(format!("read error: {}: {}", mode, err).into());
         }
     }

--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -62,6 +62,7 @@ use ::regex::Regex;
 use chrono::{DateTime, Datelike, NaiveDateTime, Utc};
 use fs::FileSystemMatcher;
 use ls::Ls;
+use std::os::unix::fs::FileTypeExt;
 use std::{
     error::Error,
     fs::{File, Metadata},
@@ -1031,6 +1032,21 @@ fn parse_files0_args(config: &mut Config) -> Result<(), Box<dyn Error>> {
         let mut file =
             File::open(mode).map_err(|e| format!("cannot open '{}' for reading: {}", mode, e))?;
         file.read_to_end(&mut buffer)?;
+
+        let meta = file
+            .metadata()
+            .map_err(|e| format!("cannot stat '{}': {}", mode, e))?;
+
+        // Read the entire file.
+        let bytes_read = file.read_to_end(&mut buffer)?;
+
+        if bytes_read == 0
+            && (meta.file_type().is_char_device() || meta.file_type().is_block_device())
+        {
+            let err =
+                std::io::Error::other("File descriptor in bad state");
+            return Err(format!("read error: {}: {}", mode, err).into());
+        }
     }
 
     let mut buffer_split: Vec<&[u8]> = buffer.split(|&b| b == 0).collect();

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -15,6 +15,7 @@ use std::io::{self, stderr, stdout, BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::SystemTime;
+use uucore::error;
 use walkdir::WalkDir;
 
 pub struct Config {
@@ -160,6 +161,8 @@ struct ParsedInfo {
 /// <https://www.gnu.org/software/findutils/manual/html_node/find_html/Starting-points.html>
 struct Files0Paths {
     reader: Box<dyn BufRead>,
+    /// Kept so that read errors can be reported GNU-style with the offending file name.
+    name: String,
 }
 
 impl Files0Paths {
@@ -168,11 +171,19 @@ impl Files0Paths {
         let reader: Box<dyn BufRead> = if name == "-" {
             Box::new(BufReader::new(io::stdin()))
         } else {
-            let file = std::fs::File::open(name)
-                .map_err(|e| format!("cannot open '{}' for reading: {}", name, e))?;
+            let file = std::fs::File::open(name).map_err(|e| {
+                format!(
+                    "cannot open ‘{}’ for reading: {}",
+                    name,
+                    error::strip_errno(&e)
+                )
+            })?;
             Box::new(BufReader::new(file))
         };
-        Ok(Self { reader })
+        Ok(Self {
+            reader,
+            name: name.to_string(),
+        })
     }
 }
 
@@ -183,7 +194,14 @@ impl Iterator for Files0Paths {
         loop {
             let mut buffer = Vec::new();
             match self.reader.read_until(0, &mut buffer) {
-                Err(e) => return Some(Err(e.into())),
+                Err(e) => {
+                    return Some(Err(format!(
+                        "‘{}’: read error: {}",
+                        self.name,
+                        error::strip_errno(&e)
+                    )
+                    .into()));
+                }
                 Ok(0) => return None,
                 Ok(_) => {}
             }

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -1442,11 +1442,15 @@ fn files0_from_special_file_read_error() {
         if !Path::new(path).exists() {
             continue;
         }
-        ucmd()
-            .arg("-files0-from")
-            .arg(path)
-            .fails()
-            .stderr_contains("read error")
-            .no_stdout();
+
+        let file_list_failure = ucmd().arg("-files0-from").arg(path).fails();
+
+        let error_output = file_list_failure.no_stdout().stderr_str();
+        assert!(
+            error_output.contains("read error")
+                || (error_output.contains("cannot open")
+                    && error_output.contains("Permission denied")),
+            "unexpected stderr for {path}: {error_output}"
+        );
     }
 }

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -1434,3 +1434,19 @@ fn find_exits_cleanly_on_broken_pipe() {
         "find panicked instead of exiting cleanly on a broken pipe:\n{stderr}"
     );
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn files0_from_special_file_read_error() {
+    for path in &["/dev/vhost-net", "/dev/vhost-vsock"] {
+        if !Path::new(path).exists() {
+            continue;
+        }
+        ucmd()
+            .arg("-files0-from")
+            .arg(path)
+            .fails()
+            .stderr_contains("read error")
+            .no_stdout();
+    }
+}

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -1631,3 +1631,19 @@ fn find_exits_cleanly_on_broken_pipe() {
         "find panicked instead of exiting cleanly on a broken pipe:\n{stderr}"
     );
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn files0_from_special_file_read_error() {
+    for path in &["/dev/vhost-net", "/dev/vhost-vsock"] {
+        if !Path::new(path).exists() {
+            continue;
+        }
+        ucmd()
+            .arg("-files0-from")
+            .arg(path)
+            .fails()
+            .stderr_contains("read error")
+            .no_stdout();
+    }
+}

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -1639,11 +1639,15 @@ fn files0_from_special_file_read_error() {
         if !Path::new(path).exists() {
             continue;
         }
-        ucmd()
-            .arg("-files0-from")
-            .arg(path)
-            .fails()
-            .stderr_contains("read error")
-            .no_stdout();
+
+        let file_list_failure = ucmd().arg("-files0-from").arg(path).fails();
+
+        let error_output = file_list_failure.no_stdout().stderr_str();
+        assert!(
+            error_output.contains("read error")
+                || (error_output.contains("cannot open")
+                    && error_output.contains("Permission denied")),
+            "unexpected stderr for {path}: {error_output}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #780 

The issue this PR referring to is somewhat fixed in `main` branch but the error message is not matched with GNU find.

**GNU find:**
```console
$ sudo find -files0-from /dev/vhost-vsock
find: ‘/dev/vhost-vsock’: read error: File descriptor in bad state
```

**Before:**
```console
$ sudo find -files0-from /dev/vhost-vsock
find: File descriptor in bad state (os error 77)
```

The diagnostic was missing the offending file name and the `read error:` wording, and it carried Rust's `(os error N)` suffix.