### PR TITLE
xargs: strip errno when arg-file doesn't exist

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -1183,11 +1183,14 @@ fn do_xargs(args: &[&str]) -> Result<CommandResult, XargsError> {
     builder_options.verbose = options.verbose;
     builder_options.close_stdin = options.arg_file.is_none();
 
-    let args_file: Box<dyn Read> = if let Some(path) = &options.arg_file {
-        Box::new(fs::File::open(path).map_err(|e| format!("Failed to open {path}: {e}"))?)
-    } else {
-        Box::new(io::stdin())
-    };
+    let args_file: Box<dyn Read> =
+        if let Some(path) = &options.arg_file {
+            Box::new(fs::File::open(path).map_err(|e| {
+                format!("Failed to open {path}: {}", uucore::error::strip_errno(&e))
+            })?)
+        } else {
+            Box::new(io::stdin())
+        };
 
     let mut args: Box<dyn ArgumentReader> = if let Some(delimiter) = options.delimiter {
         Box::new(ByteDelimitedArgumentReader::new(args_file, delimiter))


### PR DESCRIPTION
```
$ cargo run --bin xargs -- --arg-file sdf
   Compiling findutils v0.10.0 (/home/devel/Desktop/findutils)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.42s
     Running `target/debug/xargs --arg-file sdf`
Error: Failed to open sdf: No such file or directory (os error 2)
```
this PR gets rid of  the (os error 2) in the message