### PR TITLE
build: add cargo-binstall metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,14 @@ license = "MIT"
 readme = "README.md"
 description = "Rust implementation of GNU findutils"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ name }-{ target }/{ bin }{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [dependencies]
 argmax = "0.4.0"
 chrono = "0.4.45"


### PR DESCRIPTION
Point cargo-binstall at the cargo-dist release artifacts (findutils-{target}.tar.xz, zip on Windows) so 'cargo binstall findutils' installs prebuilt binaries instead of building from source.