### PR TITLE
xargs: treat whitespace-only input as no argument (fixes #771)

### DIFF
--- a/src/xargs/mod.rs
+++ b/src/xargs/mod.rs
@@ -605,7 +605,13 @@ where
                             format!("Unterminated quote: {q}"),
                         ));
                     }
-                    if i == 0 {
+                    // Input that consists only of delimiters (whitespace)
+                    // produces no argument — a run of delimiters with no
+                    // content between them yields nothing, matching GNU xargs.
+                    // `i == 0` handles the case where we read no bytes at all;
+                    // `result.is_empty()` additionally covers input we consumed
+                    // but that was pure whitespace.
+                    if result.is_empty() {
                         return Ok(None);
                     }
                     pending.clear();

--- a/tests/test_xargs.rs
+++ b/tests/test_xargs.rs
@@ -74,6 +74,50 @@ fn xargs_if_empty() {
 }
 
 #[test]
+fn xargs_whitespace_only_input() {
+    // Input that consists only of delimiters (whitespace) produces no
+    // argument, matching GNU xargs: a run of delimiters with no content
+    // between them yields no argument. The command still runs once with no
+    // extra args (the default, as with empty input).
+    ucmd().pipe_in(" ").succeeds().no_stderr().stdout_only("\n");
+
+    // Other ASCII whitespace should behave the same as a space.
+    ucmd()
+        .pipe_in("\t")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("\n");
+    ucmd()
+        .pipe_in(" \t\n \n")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("\n");
+
+    // With --no-run-if-empty, whitespace-only input means nothing to do.
+    ucmd()
+        .args(&["--no-run-if-empty"])
+        .pipe_in(" ")
+        .succeeds()
+        .no_output();
+
+    // The same holds when reading from a file with -a (issue #771 repro):
+    // the child must receive zero arguments, not an empty-string argument.
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(temp_file.path(), b" ").unwrap();
+    let result = ucmd()
+        .args(&[
+            "-a",
+            &temp_file.path().to_string_lossy(),
+            &path_to_testing_commandline(),
+            "-",
+            "--no_print_cwd",
+        ])
+        .succeeds();
+    result.no_stderr();
+    assert_eq!(result.stdout_str(), "args=\n--no_print_cwd\n");
+}
+
+#[test]
 fn xargs_replace_empty_input() {
     ucmd()
         .args(&["-I", "{}", "echo", "hello", "{}"])


### PR DESCRIPTION
Fixes #771.

## Problem

When a filename (or any input) given to `xargs` consists solely of an ASCII space, `uu xargs` passes an empty-string argument to the child process:

```
$ echo -n " " > a.txt
$ ./target/debug/xargs -a a.txt ls
ls: cannot access ''
```

GNU `xargs` instead treats the lone space as a delimiter and runs the child with no extra arguments:

```
$ xargs -a a.txt ls
<lists the cwd, exit 0>
```

The same discrepancy occurs for any whitespace-only input (space, tab, newline, runs of them) on both stdin and `-a`.

## Root cause

In `src/xargs/mod.rs`, the `WhitespaceDelimitedArgumentReader::next` loop returns `Ok(None)` at EOF only when no bytes have been read at all (`i == 0`). Input that was consumed but consisted purely of delimiters left `result` empty while `i > 0`, so the loop fell through and emitted a zero-length `Argument`. xargs then passed that empty string to the child.

## Fix

At EOF, return `Ok(None)` whenever `result` is empty, not only when `i == 0`. This makes whitespace-only input behave exactly like empty input (delimiters separate arguments; a run of delimiters with no content between them yields no argument), matching GNU `xargs`. The `i == 0` case is subsumed since no bytes read implies `result` is empty.

Behavior of normal tokenization (leading/trailing/multiple delimiters around real content, quoted/escaped args) is unchanged.

## Test

Added `xargs_whitespace_only_input` covering space, tab, mixed whitespace, `--no-run-if-empty`, and the `-a` repro from the issue (asserting the child receives zero xargs-provided arguments). All existing xargs tests still pass.

```
cargo test          # 226 + 28 (xargs) tests, all pass
cargo fmt --check   # clean
cargo clippy --all-targets -- -D warnings   # clean
```

The acceptance criterion is GNU `xargs` behavior: whitespace-only input yields no argument.

---

Developed with AI assistance and reviewed by the contributor.