### PR TITLE
fix(find): -mindepth N -maxdepth M with N>M now matches nothing

### DIFF
--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -276,6 +276,15 @@ fn process_dir(
     matcher: &dyn matchers::Matcher,
     quit: &mut bool,
 ) -> i32 {
+    // GNU/BSD find semantics: `-mindepth N -maxdepth M` with N > M matches no
+    // depth (none is simultaneously >= N and <= M), so the walk yields nothing.
+    // We must short-circuit here because walkdir's `min_depth`/`max_depth`
+    // setters silently clamp to resolve the contradiction (whichever is set last
+    // wins), which would instead surface entries at the smaller depth. See #778.
+    if config.min_depth > config.max_depth {
+        return 0;
+    }
+
     let mut walkdir = WalkDir::new(dir)
         .contents_first(config.depth_first)
         .max_depth(config.max_depth)
@@ -886,6 +895,51 @@ mod tests {
                  ./test_data/depth/1/2/f2\n"
             )
         );
+    }
+
+    #[test]
+    fn find_mindepth_greater_than_maxdepth() {
+        // `-mindepth N -maxdepth M` with N > M matches no depth, so GNU/BSD
+        // find print nothing. Regression test for #778: walkdir's setters
+        // silently clamp the contradiction, which previously surfaced entries
+        // at the smaller depth instead of nothing.
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-mindepth",
+                "2",
+                "-maxdepth",
+                "1",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
+    }
+
+    #[test]
+    fn find_mindepth_greater_than_maxdepth_reversed_order() {
+        // The depth flags may be given in either order; both must yield nothing.
+        let deps = FakeDependencies::new();
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-maxdepth",
+                "1",
+                "-mindepth",
+                "2",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #778.

## Problem

`find <dir> -mindepth N -maxdepth M` with `N > M` printed entries at the smaller depth instead of nothing. Repro (against current `main`, commit `1f19cdd`):

```
$ mkdir -p depth-repro/1/2/3 && touch depth-repro/1/f1 depth-repro/f0
$ ./target/debug/find depth-repro -mindepth 2 -maxdepth 1
depth-repro/1
depth-repro/f0
```

GNU/BSD find print nothing here (no depth is simultaneously `>= N` and `<= M`):

```
$ find depth-repro -mindepth 2 -maxdepth 1   # BSD find, macOS
$                                            # (no output, exit 0)
```

## Root cause

`process_dir` builds the walker with `walkdir`'s `min_depth`/`max_depth` setters (`src/find/mod.rs`). Those setters **silently clamp** the contradiction — whichever is set last wins (walkdir `src/lib.rs`):

```rust
pub fn min_depth(mut self, depth: usize) -> Self {
    self.opts.min_depth = depth;
    if self.opts.min_depth > self.opts.max_depth {
        self.opts.min_depth = self.opts.max_depth;   // clamps min DOWN
    }
    self
}
pub fn max_depth(mut self, depth: usize) -> Self {
    self.opts.max_depth = depth;
    if self.opts.max_depth < self.opts.min_depth {
        self.opts.max_depth = self.opts.min_depth;   // clamps max UP
    }
    self
}
```

uutils calls `.max_depth()` first, then `.min_depth()`, so with `max_depth=1, min_depth=2` the second call clamps `min_depth` down to `1` → the walk yields exactly the depth-1 entries.

## Fix

Add an explicit guard at the top of `process_dir` that returns early (no output) when `config.min_depth > config.max_depth`, matching GNU/BSD find. The walkdir builder is left untouched.

```rust
// GNU/BSD find semantics: `-mindepth N -maxdepth M` with N > M matches no
// depth (none is simultaneously >= N and <= M), so the walk yields nothing.
// We must short-circuit here because walkdir's `min_depth`/`max_depth`
// setters silently clamp to resolve the contradiction (whichever is set last
// wins), which would instead surface entries at the smaller depth. See #778.
if config.min_depth > config.max_depth {
    return 0;
}
```

## Verification

- `cargo build --bin find` — clean
- `cargo test` — 228 lib tests + integration suites pass (0 failures), including two new regression tests:
  - `find_mindepth_greater_than_maxdepth` (`-mindepth 2 -maxdepth 1`)
  - `find_mindepth_greater_than_maxdepth_reversed_order` (`-maxdepth 1 -mindepth 2`, both orderings must yield nothing)
- `cargo fmt --check` — clean
- `cargo clippy --lib -- -D warnings` — clean
- Manual repro now matches GNU/BSD: `find depth-repro -mindepth 2 -maxdepth 1` → no output, exit 0

The existing `find_mindepth` / `find_maxdepth` / `find_zero_maxdepth` tests continue to pass unchanged.