### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 license = "MIT"
 readme = "README.md"
 description = "Rust implementation of GNU findutils"
-authors = ["uutils developers"]
 
 [dependencies]
 argmax = "0.4.0"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,5 +1,4 @@
 [book]
-authors = ["Terts Diepraam"]
 language = "en"
 multilingual = false
 src = "src"


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068