### PR TITLE
find: stream -files0-from input instead of reading it all into memory

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -65,7 +65,6 @@ use ls::Ls;
 use std::{
     error::Error,
     fs::{File, Metadata},
-    io::Read,
     path::Path,
     str::FromStr,
     time::SystemTime,
@@ -1010,48 +1009,7 @@ fn build_matcher_tree(
              did not see one.",
         ));
     }
-    if config.files0_argument.is_some() {
-        parse_files0_args(config)?;
-    }
     Ok((i, top_level_matcher.build()))
-}
-
-// https://www.gnu.org/software/findutils/manual/html_node/find_html/Starting-points.html
-// This allows users to take the entry point for find from stdin (eg. pipe) or from a text file.
-// eg. dummy | find -files0-from -
-// eg. find -files0-from rust.txt -name "cargo"
-fn parse_files0_args(config: &mut Config) -> Result<(), Box<dyn Error>> {
-    let mode = config.files0_argument.as_ref().unwrap();
-    let mut buffer = Vec::new();
-    let new_paths = config.new_paths.insert(Vec::new());
-
-    if mode == "-" {
-        std::io::stdin().read_to_end(&mut buffer)?;
-    } else {
-        let mut file =
-            File::open(mode).map_err(|e| format!("cannot open '{}' for reading: {}", mode, e))?;
-        file.read_to_end(&mut buffer)?;
-    }
-
-    let mut buffer_split: Vec<&[u8]> = buffer.split(|&b| b == 0).collect();
-    // if the pipe/file ends with ASCII NULL
-    if buffer_split.last().is_some_and(|s| s.is_empty()) {
-        buffer_split.remove(buffer_split.len() - 1);
-    }
-
-    let mut string_segments: Vec<String> = buffer_split
-        .iter()
-        .map(|segment| std::str::from_utf8(segment).map(std::string::ToString::to_string))
-        .collect::<Result<_, _>>()?;
-    // empty starting point checker
-    if string_segments.iter().any(std::string::String::is_empty) {
-        eprintln!("find: invalid zero-length file name");
-        // remove the empty ones so as to avoid file not found error
-        string_segments.retain(|s| !s.is_empty());
-    }
-
-    new_paths.extend(string_segments);
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -28,7 +28,6 @@ pub struct Config {
     today_start: bool,
     no_leaf_dirs: bool,
     follow: Follow,
-    new_paths: Option<Vec<String>>,
     files0_argument: Option<String>,
 }
 
@@ -48,8 +47,7 @@ impl Default for Config {
             // a compatibility item for GNU findutils.
             no_leaf_dirs: false,
             follow: Follow::Never,
-            new_paths: None, // This option exclusively for -files0-from argument.
-            files0_argument: None, //This option also is used for file0-from
+            files0_argument: None, // This option exclusively for -files0-from argument.
         }
     }
 }
@@ -146,7 +144,58 @@ impl Dependencies for StandardDependencies {
 struct ParsedInfo {
     matcher: Box<dyn self::matchers::Matcher>,
     paths: Vec<String>,
+    /// Starting points supplied via `-files0-from`, read lazily so that an
+    /// endless or very large input (e.g. `-files0-from /dev/urandom`) does not
+    /// have to fit in memory.
+    files0_paths: Option<Files0Paths>,
     config: Config,
+}
+
+/// Iterator over the NUL-separated starting points of `-files0-from`.
+///
+/// <https://www.gnu.org/software/findutils/manual/html_node/find_html/Starting-points.html>
+struct Files0Paths {
+    reader: Box<dyn BufRead>,
+}
+
+impl Files0Paths {
+    /// Open the source named by `-files0-from`; `-` means standard input.
+    fn open(name: &str) -> Result<Self, Box<dyn Error>> {
+        let reader: Box<dyn BufRead> = if name == "-" {
+            Box::new(BufReader::new(io::stdin()))
+        } else {
+            let file = std::fs::File::open(name)
+                .map_err(|e| format!("cannot open '{}' for reading: {}", name, e))?;
+            Box::new(BufReader::new(file))
+        };
+        Ok(Self { reader })
+    }
+}
+
+impl Iterator for Files0Paths {
+    type Item = Result<String, Box<dyn Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let mut buffer = Vec::new();
+            match self.reader.read_until(0, &mut buffer) {
+                Err(e) => return Some(Err(e.into())),
+                Ok(0) => return None,
+                Ok(_) => {}
+            }
+            // A trailing separator terminates the name; without one we are at
+            // EOF and the bytes read are still a name.
+            if buffer.last() == Some(&0) {
+                buffer.pop();
+            }
+            if buffer.is_empty() {
+                // Skip it so as to avoid a file not found error.
+                eprintln!("find: invalid zero-length file name");
+                continue;
+            }
+            return Some(String::from_utf8(buffer).map_err(Into::into));
+        }
+    }
 }
 
 /// Function to generate a `ParsedInfo` from the strings supplied on the command-line.
@@ -187,9 +236,11 @@ fn parse_args(args: &[&str]) -> Result<ParsedInfo, Box<dyn Error>> {
         paths.push(".".to_string());
     }
     let matcher = matchers::build_top_level_matcher(&args[i..], &mut config)?;
-    if let Some(new_paths) = &config.new_paths {
+    let mut files0_paths = None;
+    if let Some(name) = &config.files0_argument {
         if paths.len() == 1 && paths[0] == "." {
-            paths.clone_from(new_paths);
+            files0_paths = Some(Files0Paths::open(name)?);
+            paths.clear();
         } else {
             return Err(From::from(format!(
                 "extra operand '{}'\nfile operands cannot be combined with -files0-from",
@@ -200,6 +251,7 @@ fn parse_args(args: &[&str]) -> Result<ParsedInfo, Box<dyn Error>> {
     Ok(ParsedInfo {
         matcher,
         paths,
+        files0_paths,
         config,
     })
 }
@@ -288,9 +340,16 @@ fn do_find(args: &[&str], deps: &dyn Dependencies) -> Result<i32, Box<dyn Error>
         return Ok(0);
     }
 
+    let paths: Box<dyn Iterator<Item = Result<String, Box<dyn Error>>>> =
+        match paths_and_matcher.files0_paths {
+            Some(files0_paths) => Box::new(files0_paths),
+            None => Box::new(paths_and_matcher.paths.into_iter().map(Ok)),
+        };
+
     let mut ret = 0;
     let mut quit = false;
-    for path in paths_and_matcher.paths {
+    for path in paths {
+        let path = path?;
         let dir_ret = process_dir(
             &path,
             &paths_and_matcher.config,

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -237,6 +237,19 @@ fn files0_pipe_double_nul() {
         .stdout_contains("./test_data/");
 }
 
+/// The starting points are read incrementally, so output for the earlier ones
+/// appears even though a later one is invalid UTF-8 (see issue #779: the input
+/// used to be slurped into memory in its entirety before anything was walked).
+#[test]
+fn files0_streams_before_invalid_utf8() {
+    ucmd()
+        .pipe_in(b"./test_data/simple\0\xff\0" as &[u8])
+        .args(&["-files0-from", "-"])
+        .fails()
+        .stdout_contains("./test_data/simple")
+        .stderr_contains("invalid utf-8 sequence");
+}
+
 #[test]
 fn files0_no_file() {
     #[cfg(unix)]


### PR DESCRIPTION
Fixes #779.

## Problem

`parse_files0_args` read the entire `-files0-from` source with `read_to_end` before splitting it on NUL, so `find -files0-from /dev/urandom` (or `/dev/zero`, or any very large list) grew the buffer without bound and never walked a single starting point.

## Fix

The starting points are now produced lazily by a `Files0Paths` iterator built on `BufRead::read_until(0, ..)`, and `do_find` walks each one as soon as it is read. The source is still opened during argument parsing, so `cannot open ... for reading` is still reported before any traversal starts.

Behaviour is otherwise unchanged: a trailing NUL still terminates the last name rather than producing an empty one, zero-length names still warn `invalid zero-length file name` and are skipped, and invalid UTF-8 is still an error — the difference is that it now surfaces when that entry is reached, after the earlier valid entries have been walked, which is closer to the GNU behaviour described in the issue.

Measured on this branch (macOS, `/usr/bin/time -l`):

```
$ /usr/bin/time -l ./target/debug/find -files0-from /dev/urandom
             1884520  peak memory footprint

$ /usr/bin/time -l timeout 3 ./target/debug/find -files0-from /dev/zero > /dev/null
             1048864  peak memory footprint
```

I also checked `src/xargs`: it already reads its input incrementally and shares no code with this path.

## Test

Bounded memory is awkward to assert in the test suite, so the new test covers the observable consequence of streaming: `files0_streams_before_invalid_utf8` feeds `./test_data/simple\0\xff\0` and asserts the valid starting point is printed before the UTF-8 error. That fails on the previous slurp-everything implementation.

## Verification

- `cargo test` — 226 + 60 + 27 + 25 + 15 + 6 passed, 0 failed
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean

---

Disclosure: this change was prepared with AI assistance (Claude). I reviewed the diff and ran the checks above myself.