### PR TITLE
find: avoid panic on a non-UTF-8 argument

### DIFF
--- a/src/find/main.rs
+++ b/src/find/main.rs
@@ -4,14 +4,59 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use std::ffi::OsString;
+
+/// Collect the process arguments as UTF-8 strings.
+///
+/// Unlike `std::env::args`, which panics on a non-UTF-8 argument, this reads the
+/// arguments with `args_os` and reports the first invalid one as an error so the
+/// caller can exit gracefully instead of aborting (#816).
+fn collect_utf8_args(args: impl Iterator<Item = OsString>) -> Result<Vec<String>, OsString> {
+    args.map(OsString::into_string).collect()
+}
+
 fn main() {
     // Ignores the SIGPIPE signal.
     // This is to solve the problem that when find is used with a pipe character,
     // the downstream software of the standard output stream closes the pipe and triggers a panic.
     uucore::panic::mute_sigpipe_panic();
 
-    let args = std::env::args().collect::<Vec<String>>();
+    let args = match collect_utf8_args(std::env::args_os()) {
+        Ok(args) => args,
+        Err(invalid) => {
+            eprintln!(
+                "find: invalid (non-UTF-8) argument: {}",
+                invalid.to_string_lossy()
+            );
+            std::process::exit(1);
+        }
+    };
     let strs: Vec<&str> = args.iter().map(std::convert::AsRef::as_ref).collect();
     let deps = findutils::find::StandardDependencies::new();
     std::process::exit(findutils::find::find_main(&strs, &deps));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_utf8_args;
+    use std::ffi::OsString;
+
+    #[test]
+    fn collects_valid_utf8_args() {
+        let args = [OsString::from("find"), OsString::from("-printf")];
+        assert_eq!(
+            collect_utf8_args(args.into_iter()).unwrap(),
+            vec!["find".to_string(), "-printf".to_string()]
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn non_utf8_arg_is_rejected_not_panicking() {
+        use std::os::unix::ffi::OsStringExt;
+        // A non-UTF-8 argument (e.g. `-printf $'%\xff'`) must produce an error
+        // instead of panicking in std::env::args (#816).
+        let args = [OsString::from("find"), OsString::from_vec(vec![b'%', 0xff])];
+        assert!(collect_utf8_args(args.into_iter()).is_err());
+    }
 }

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -129,6 +129,19 @@ fn invalid_newerxy_predicate_is_rejected() {
         .no_stdout();
 }
 
+#[cfg(unix)]
+#[test]
+fn non_utf8_argument_is_rejected_gracefully() {
+    // A non-UTF-8 argument must produce a clean error, not a panic (#816).
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    ucmd()
+        .arg(OsString::from_vec(vec![b'-', b'p', 0xff]))
+        .fails()
+        .stderr_contains("non-UTF-8")
+        .no_stdout();
+}
+
 #[test]
 fn size_rejects_non_numeric_prefix() {
     // A non-numeric prefix or an invalid double sign is rejected, matching GNU.


### PR DESCRIPTION
## Summary

A non-UTF-8 argument makes `find` panic during argument collection, before the format
parser is ever reached:

```
$ find d -printf $'%\xff|\n'
thread 'main' panicked at ...: called `Result::unwrap()` on an `Err` value
$ echo $?
101
```

## Root cause

`main` collected arguments with `std::env::args()`, which panics on a non-UTF-8 argument.

## Fix

Collect with `std::env::args_os()` and report the first non-UTF-8 argument as an error,
exiting with code 1 instead of aborting. The conversion is extracted into a small
`collect_utf8_args` helper so it can be unit-tested. Full GNU-style byte pass-through of
the format string is a larger change and left as a follow-up.

## Verification

```
$ find d -printf $'%\xff|\n'
find: invalid (non-UTF-8) argument: %<0xff>|
$ echo $?
1
```

Adds unit tests `collects_valid_utf8_args` and `non_utf8_arg_is_rejected_not_panicking`.
`cargo fmt` and `cargo clippy --bin find` are clean.

Fixes #816.
