### PR TITLE
find: reject a non-numeric prefix in the -size argument

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -340,7 +340,11 @@ fn convert_arg_to_comparable_value_and_suffix(
     option_name: &str,
     value_as_string: &str,
 ) -> Result<(ComparableValue, String), Box<dyn Error>> {
-    let re = Regex::new(r"([-+]?)[-+]?(\d+)(.*)$")?;
+    // Anchor at the start so a non-numeric prefix like "x5c" is rejected instead
+    // of silently parsing the "5c" in the middle. After the comparison sign GNU
+    // accepts one more optional '+' (so "++5c" and "-+5c" are valid, but "+-5c"
+    // and "--5c" are not), which `\+?` reproduces.
+    let re = Regex::new(r"^([-+]?)\+?(\d+)(.*)$")?;
     if let Some(groups) = re.captures(value_as_string) {
         if let Ok(val) = groups[2].parse::<u64>() {
             return Ok((

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -130,6 +130,21 @@ fn invalid_newerxy_predicate_is_rejected() {
 }
 
 #[test]
+fn size_rejects_non_numeric_prefix() {
+    // A non-numeric prefix or an invalid double sign is rejected, matching GNU.
+    for bad in ["x5c", "abc5c", "+-5c", "--5c", "+++5c"] {
+        ucmd()
+            .args(&["./test_data", "-size", bad])
+            .fails()
+            .stderr_contains("argument to -size")
+            .no_stdout();
+    }
+    for good in ["5c", "+5c", "-5c", "++5c", "-+5c"] {
+        ucmd().args(&["./test_data", "-size", good]).succeeds();
+    }
+}
+
+#[test]
 fn multiple_matcher_failure() {
     ucmd()
         .args(&["-type", "fd", "-name", "abbb"])


### PR DESCRIPTION
## Problem

`find`'s `-size` argument was parsed with an un-anchored regex
(`([-+]?)[-+]?(\d+)(.*)$`), so a non-numeric prefix was silently accepted:

```
$ find . -size x5c      # matched as if it were "-size 5c"
$ find . -size abc5c    # same
```

GNU `find` rejects these with `find: Invalid argument 'x5c' to -size`. The extra
sign group also accepted `+-5c` and `--5c`, which GNU rejects too.

## Fix

Anchor the regex at the start and replace the second `[-+]?` with `\+?`, which
matches GNU's grammar exactly: after the comparison sign GNU accepts one more
optional `+` (so `++5c` and `-+5c` are valid), but not a second `-`.

## Verification

Compared against GNU findutils (`gfind`) over 13 `-size` inputs; exit codes and
the matched file sets are identical:

| input | before | after / GNU |
|-------|--------|-------------|
| `x5c`, `abc5c` | accepted | rejected |
| `+-5c`, `--5c`, `+++5c` | accepted | rejected |
| `5c`, `+5c`, `-5c`, `++5c`, `-+5c` | accepted | accepted (same comparison) |

`-mtime`/`-inum` numeric parsing is unchanged. Added a unit test; the full
`cargo test --lib` suite (227 tests) passes and `cargo fmt` / `cargo clippy` are
clean.
