### PR TITLE
find: reject a signed -maxdepth/-mindepth value to match GNU

### DIFF
--- a/src/find/matchers/mod.rs
+++ b/src/find/matchers/mod.rs
@@ -307,8 +307,10 @@ fn convert_arg_to_number(
     option_name: &str,
     value_as_string: &str,
 ) -> Result<usize, Box<dyn Error>> {
+    // Only accept plain decimal digits. Rust's `usize::from_str` also accepts a
+    // leading '+', but GNU find rejects a signed value like "+1" here.
     match value_as_string.parse::<usize>() {
-        Ok(val) => Ok(val),
+        Ok(val) if value_as_string.bytes().all(|b| b.is_ascii_digit()) => Ok(val),
         _ => Err(From::from(format!(
             "Expected a positive decimal integer argument to {option_name}, but got \
              `{value_as_string}'"

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -158,6 +158,18 @@ fn size_rejects_non_numeric_prefix() {
 }
 
 #[test]
+fn depth_rejects_signed_value() {
+    // A signed depth like "+1" is rejected, matching GNU find.
+    for opt in ["-maxdepth", "-mindepth"] {
+        ucmd()
+            .args(&["./test_data", opt, "+1"])
+            .fails()
+            .stderr_contains("positive decimal integer argument");
+        ucmd().args(&["./test_data", opt, "1"]).succeeds();
+    }
+}
+
+#[test]
 fn multiple_matcher_failure() {
     ucmd()
         .args(&["-type", "fd", "-name", "abbb"])


### PR DESCRIPTION
## Problem

`-maxdepth`/`-mindepth` accepted a `+`-signed value that GNU rejects:

```
$ find dir -maxdepth +1     # uutils: runs normally (parsed as 1)
$ gfind dir -maxdepth +1
find: Expected a positive decimal integer argument to -maxdepth, but got '+1'
```

Rust's `usize::from_str` accepts a leading `+`, so `convert_arg_to_number` let
it through, which is inconsistent with the function's own "positive decimal
integer" error message.

## Fix

Only accept plain decimal digits.

## Verification

Compared against GNU findutils (`gfind`) for `-maxdepth` and `-mindepth` over
`1`, `+1`, `-1`, `+2`, `0`, `2`; exit codes match in every case. Added a unit
test; `cargo test --lib` passes and `cargo fmt` / `cargo clippy` are clean.
