### PR TITLE
fix: make --version output consistent across utilities

### DIFF
--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -408,7 +408,7 @@ Actions:
 fn print_version(deps: &dyn Dependencies) -> Result<(), io::Error> {
     writeln!(
         &mut deps.get_output().borrow_mut(),
-        "find (Rust) {}",
+        "find {}",
         env!("CARGO_PKG_VERSION")
     )
 }

--- a/src/updatedb/mod.rs
+++ b/src/updatedb/mod.rs
@@ -265,7 +265,9 @@ impl Dependencies for CapturedDependencies {
 }
 
 fn do_updatedb(args: &[&str]) -> UResult<()> {
-    let matches = uu_app().try_get_matches_from(args)?;
+    let matches = uu_app()
+        .try_get_matches_from(args)
+        .unwrap_or_else(|e| e.exit());
     let config = Config::from(matches);
 
     // offload most of the logic to find. Build the argument list as discrete tokens rather than

--- a/src/updatedb/mod.rs
+++ b/src/updatedb/mod.rs
@@ -265,9 +265,16 @@ impl Dependencies for CapturedDependencies {
 }
 
 fn do_updatedb(args: &[&str]) -> UResult<()> {
-    let matches = uu_app()
-        .try_get_matches_from(args)
-        .unwrap_or_else(|e| e.exit());
+    let matches = match uu_app().try_get_matches_from(args) {
+        Ok(m) => m,
+        Err(e) => match e.kind() {
+            clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
+                print!("{e}");
+                return Ok(());
+            }
+            _ => return Err(uucore::error::UClapError::with_exit_code(e, 1).into()),
+        },
+    };
     let config = Config::from(matches);
 
     // offload most of the logic to find. Build the argument list as discrete tokens rather than

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -153,6 +153,50 @@ fn test_locate_print_help() {
 }
 
 #[test]
+fn test_locate_version() {
+    let assert = Command::cargo_bin("locate")
+        .expect("couldn't find locate binary")
+        .arg("--version")
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.starts_with("locate "),
+        "expected stdout to start with 'locate ', got: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_updatedb_version() {
+    // Regression test: `updatedb --version` used to print
+    // "Error: updatedb X.Y.Z" to stderr and exit non-zero. It must print
+    // "updatedb X.Y.Z" to stdout and succeed, like the other utilities.
+    let assert = Command::cargo_bin("updatedb")
+        .expect("couldn't find updatedb binary")
+        .arg("--version")
+        .assert()
+        .success();
+
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stdout.starts_with("updatedb "),
+        "expected stdout to start with 'updatedb ', got: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("Error") && !stderr.contains("Error"),
+        "version output must not contain 'Error': stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "--version should write nothing to stderr, got: {stderr:?}"
+    );
+}
+
+#[test]
 fn test_locate_invalid_flag() {
     Command::cargo_bin("locate")
         .expect("couldn't find locate binary")

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -51,6 +51,36 @@ fn no_args() {
 }
 
 #[test]
+fn find_version() {
+    // Regression test: `find --version` used to print "find (Rust) X.Y.Z",
+    // deviating from the format used by the other utilities. It must print
+    // "find X.Y.Z" to stdout and exit successfully.
+    let output = ucmd().arg("--version").succeeds();
+    let result = output.no_stderr();
+
+    assert!(
+        result.stdout_str().starts_with("find "),
+        "expected stdout to start with 'find ', got: {:?}",
+        result.stdout_str()
+    );
+    assert!(
+        !result.stdout_str().contains("(Rust)"),
+        "version output should not contain '(Rust)': {:?}",
+        result.stdout_str()
+    );
+
+    let second_word = result.stdout_str().split_whitespace().nth(1).unwrap_or("");
+    assert!(
+        second_word
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit()),
+        "expected the second word to be the version number, got: {:?}",
+        result.stdout_str()
+    );
+}
+
+#[test]
 fn two_matchers_both_match() {
     ucmd()
         .args(&["-type", "d", "-name", "test_data"])


### PR DESCRIPTION
Fixes #837.

## Problem

The `--version` output is inconsistent across utilities.

**Updated behavior:**

```sh
$ ./find --version
find 0.10.0

$ ./locate --version
locate 0.10.0

$ ./updatedb --version
updatedb 0.10.0

$ ./xargs --version
xargs 0.10.0