### PR TITLE
find: accept egrep and posix-egrep regex types to match GNU

### DIFF
--- a/src/find/matchers/regex.rs
+++ b/src/find/matchers/regex.rs
@@ -70,6 +70,8 @@ impl FromStr for RegexType {
             "posix-extended" => Ok(Self::PosixExtended),
             // ed and sed are the same as posix-basic
             "ed" | "sed" => Ok(Self::PosixBasic),
+            // egrep and posix-egrep are the same as posix-extended
+            "egrep" | "posix-egrep" => Ok(Self::PosixExtended),
             _ => Err(ParseRegexTypeError(s.to_owned())),
         }
     }
@@ -221,5 +223,18 @@ mod tests {
         .unwrap();
         let deps = FakeDependencies::new();
         assert!(!matcher.matches(&abbbc, &mut deps.new_matcher_io()));
+    }
+
+    #[test]
+    fn egrep_aliases_map_to_posix_extended() {
+        // GNU accepts egrep and posix-egrep as names for the extended syntax.
+        assert_eq!(
+            "egrep".parse::<RegexType>().unwrap(),
+            RegexType::PosixExtended
+        );
+        assert_eq!(
+            "posix-egrep".parse::<RegexType>().unwrap(),
+            RegexType::PosixExtended
+        );
     }
 }


### PR DESCRIPTION
GNU `find` accepts `egrep` and `posix-egrep` as `-regextype` names; both select the extended (ERE) syntax. uutils rejects them:

```
$ find . -regextype egrep -regex '.*'
find: Invalid regex type: egrep (must be one of 'emacs', 'grep', 'posix-basic', 'posix-extended')
```

They behave identically to the already-supported `posix-extended`. Verified against GNU with a `+` quantifier: `egrep`, `posix-egrep` and `posix-extended` all match the same paths. This maps both aliases to `PosixExtended`, mirroring how `ed`/`sed` already alias `posix-basic`.

Left out on purpose: GNU's `awk`, `gnu-awk`, `posix-awk` and `posix-minimal-basic` have small semantic differences that the onig syntaxes do not represent exactly, so they are not added here.
