### PR TITLE
find: do not double the "find:" prefix on an invalid -type list

### DIFF
--- a/src/find/matchers/type_matcher.rs
+++ b/src/find/matchers/type_matcher.rs
@@ -107,7 +107,7 @@ fn type_creator(type_string: &str, mode: &str) -> Result<HashSet<FileType>, Box<
     if type_string.contains(',') {
         for part in type_string.split(',') {
             if part.is_empty() {
-                return Err(From::from(format!("find: Last file type in list argument to {mode} is missing, i.e., list is ending on: ','")));
+                return Err(From::from(format!("Last file type in list argument to {mode} is missing, i.e., list is ending on: ','")));
             }
             let file_type = parse(part, mode)?;
             if !file_types.insert(file_type) {

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -181,6 +181,8 @@ fn multiple_matcher_failure() {
         .args(&["-type", "f,", "-name", "abbb"])
         .fails()
         .stderr_contains("list is ending on: ','")
+        // GNU prints a single "find: " prefix; the message must not double it.
+        .stderr_does_not_contain("find: find:")
         .no_stdout();
 
     ucmd()
@@ -212,6 +214,7 @@ fn multiple_matcher_failure() {
         .args(&["-xtype", "f,", "-name", "abbb"])
         .fails()
         .stderr_contains("list is ending on: ','")
+        .stderr_does_not_contain("find: find:")
         .no_stdout();
 
     ucmd()


### PR DESCRIPTION
A `-type`/`-xtype` list that ends in a comma prints the `find:` prefix twice:

```
$ find . -type f,
find: find: Last file type in list argument to -type is missing, i.e., list is ending on: ','
```

GNU prints it once:

```
$ find . -type f,
find: Last file type in list argument to -type is missing, i.e., list is ending on: ','
```

The message in `type_creator` hardcodes a leading `find: `, but the top level error printer already prepends `find: {e}`. The two sibling messages in the same function (the duplicate type and the missing separator ones) do not hardcode it, so this one is inconsistent. Drop the hardcoded prefix so the output matches GNU and the neighbors.
