### PR TITLE
find: reject the deprecated -perm +MODE octal form to match GNU

### DIFF
--- a/src/find/matchers/perm.rs
+++ b/src/find/matchers/perm.rs
@@ -53,6 +53,13 @@ mod parsing {
     }
 
     pub fn parse_mode(pattern: &str, for_dir: bool) -> Result<u32, Box<dyn Error>> {
+        // GNU rejects the old `-perm +MODE` octal form; a leading + needs a symbolic mode.
+        if let Some(rest) = pattern.strip_prefix('+') {
+            if rest.contains(|c: char| c.is_ascii_digit()) {
+                return Err(From::from(format!("invalid mode '+{rest}'")));
+            }
+        }
+
         let mode = if pattern.contains(|c: char| c.is_ascii_digit()) {
             parse_numeric(0, pattern, for_dir)?
         } else {

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -792,6 +792,21 @@ fn find_perm() {
 
 #[cfg(unix)]
 #[test]
+fn find_perm_plus_octal_is_rejected() {
+    // GNU find rejects the deprecated `-perm +MODE` octal form; only symbolic
+    // modes may follow a leading `+`.
+    ucmd()
+        .args(&["-perm", "+644"])
+        .fails()
+        .stderr_contains("invalid mode '+644'");
+    ucmd()
+        .args(&["-perm", "+0"])
+        .fails()
+        .stderr_contains("invalid mode '+0'");
+}
+
+#[cfg(unix)]
+#[test]
 fn find_inum() {
     use std::os::unix::fs::MetadataExt;
 


### PR DESCRIPTION
GNU `find` rejects the deprecated `-perm +MODE` octal form (a leading `+` followed by an octal number). uutils silently accepts it: the `+` is treated as an unknown prefix, so it falls through to an exact numeric comparison and matches files instead of erroring.

```
$ find . -perm +644 ; echo $?
./f          # wrongly matches
0
$ gfind . -perm +644 ; echo $?
gfind: invalid file mode '+644'
1
```

Same for `+0` and `+400`. Symbolic forms (`+rwx`, `+u+w`) and the `644` / `/644` / `-644` forms are unaffected. This rejects a leading `+` followed by a digit, matching GNU.
