### PR TITLE
fix(find): output nothing when -mindepth exceeds -maxdepth

### DIFF
--- a/src/find/mod.rs
+++ b/src/find/mod.rs
@@ -276,6 +276,13 @@ fn process_dir(
     matcher: &dyn matchers::Matcher,
     quit: &mut bool,
 ) -> i32 {
+    // No depth can be both >= min_depth and <= max_depth when min_depth exceeds
+    // max_depth, so nothing matches — the same as GNU find. `WalkDir` would
+    // otherwise still yield the max-depth entries, so short-circuit here.
+    if config.min_depth > config.max_depth {
+        return 0;
+    }
+
     let mut walkdir = WalkDir::new(dir)
         .contents_first(config.depth_first)
         .max_depth(config.max_depth)
@@ -736,6 +743,29 @@ mod tests {
                  ./test_data/depth/f0\n"
             )
         );
+    }
+
+    #[test]
+    fn find_mindepth_greater_than_maxdepth() {
+        // -mindepth greater than -maxdepth can never be satisfied, so find
+        // outputs nothing, matching GNU find (issue #778).
+        let deps = FakeDependencies::new();
+
+        let rc = find_main(
+            &[
+                "find",
+                &fix_up_slashes("./test_data/depth"),
+                "-sorted",
+                "-mindepth",
+                "2",
+                "-maxdepth",
+                "1",
+            ],
+            &deps,
+        );
+
+        assert_eq!(rc, 0);
+        assert_eq!(deps.get_output_as_string(), "");
     }
 
     #[test]

--- a/tests/test_find.rs
+++ b/tests/test_find.rs
@@ -170,6 +170,16 @@ fn depth_rejects_signed_value() {
 }
 
 #[test]
+fn mindepth_exceeds_maxdepth_outputs_nothing() {
+    // When -mindepth is greater than -maxdepth no entry can match, so find
+    // prints nothing and exits successfully, matching GNU find.
+    ucmd()
+        .args(&["./test_data/simple", "-mindepth", "2", "-maxdepth", "1"])
+        .succeeds()
+        .no_stdout();
+}
+
+#[test]
 fn multiple_matcher_failure() {
     ucmd()
         .args(&["-type", "fd", "-name", "abbb"])


### PR DESCRIPTION
Fixes #778

## Problem

When `-mindepth` is greater than `-maxdepth`, `find` should output nothing (no depth can be both `>= mindepth` and `<= maxdepth`), matching GNU find. uutils instead printed the max-depth entries:

```console
$ find . -mindepth 2 -maxdepth 1     # GNU: (nothing)
$ ./find . -mindepth 2 -maxdepth 1   # uutils, before:
./a
./f0
```

## Cause

`process_dir` passes both bounds to `WalkDir::min_depth`/`max_depth`. When `min_depth > max_depth`, `WalkDir` does not yield the empty set — it effectively clamps the range and still yields entries at the max depth, so they leak through.

## Fix

Short-circuit in `process_dir`: when `config.min_depth > config.max_depth`, return early with no output, matching GNU find.

## Tests

Adds `find_mindepth_greater_than_maxdepth`, which asserts empty output for `-mindepth 2 -maxdepth 1`. It **fails without the fix** (the max-depth entries are printed) and passes with it. `cargo fmt --check` and `cargo clippy` are clean; normal min/max combinations are unaffected.